### PR TITLE
fix(ci): upgrade peter-evans/create-pull-request to v7

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "docs: update CHANGELOG.md"
           title: "docs: update CHANGELOG.md"


### PR DESCRIPTION
## Summary

`Update Changelog` ワークフローで発生していた "Duplicate header: Authorization" エラーを修正。

## Problem

`actions/checkout@v6` と `peter-evans/create-pull-request@v6` の組み合わせで、認証ヘッダーが重複し HTTP 400 エラーが発生していました。

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/lihs-ie/lambars/': The requested URL returned error: 400
```

## Solution

`peter-evans/create-pull-request` を v6 から v7 にアップグレード。この問題は v7.0.9 で修正されています。

## Reference

- https://github.com/actions/checkout/issues/2215

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] CI workflow changes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)