### PR TITLE
docs(internal): add future work priorities list

### DIFF
--- a/docs/internal/future_work_priorities.yaml
+++ b/docs/internal/future_work_priorities.yaml
@@ -79,7 +79,7 @@ priorities:
         rationale: |
           Either/Result など二つの型パラメータを持つ型で必須。
           Haskell, cats-core で基本型クラスとして提供されている。
-        github_issue: null
+        github_issue: 170
         references:
           - docs/internal/requirements/20250101_0000_typeclass.yaml
 
@@ -91,7 +91,7 @@ priorities:
           パーサーコンビネータ等で即効性が高い。
           nom や combine との連携で価値がある。
           empty と orElse (|) を持つ Applicative の拡張。
-        github_issue: null
+        github_issue: 171
         references:
           - docs/internal/requirements/20250101_0000_typeclass.yaml
 
@@ -104,7 +104,7 @@ priorities:
           Functor の代わりに型レベルのリストを使用。
           Rust では HKT 制約を回避できるため、Free より実装しやすい。
           DSL 構築の基盤として重要。
-        github_issue: null
+        github_issue: 172
         references:
           - docs/internal/requirements/20250101_0200_control.yaml
 
@@ -134,7 +134,7 @@ priorities:
           Phase 3 の Continuation との統合。
           高度な制御フローに必要。
           TrampolineT, ContinuationT もこの実装に統合。
-        github_issue: null
+        github_issue: 173
         references:
           - docs/internal/requirements/20250101_0500_effect.yaml
           - docs/internal/requirements/20250101_0200_control.yaml
@@ -147,7 +147,7 @@ priorities:
           非決定的選択を扱う Transformer。
           バックトラッキングの実装に有用。
           AI/探索アルゴリズム向け。
-        github_issue: null
+        github_issue: 174
         dependencies: [FW-005]
         note: ContT/MonadTrans 基盤に依存
         references:
@@ -161,7 +161,7 @@ priorities:
           既存の optics と persistent の連携強化。
           persistent_optics.rs が存在するため拡張が容易。
           深いネストへの効率的なアクセスと不変更新の簡略化。
-        github_issue: null
+        github_issue: 175
         references:
           - docs/internal/requirements/20250101_0300_persistent.yaml
 
@@ -176,7 +176,7 @@ priorities:
           反変ファンクター。入力の型に対して contramap を持つ。
           Predicate<A>: contramap(f: B -> A) -> Predicate<B>
           使用頻度は低めだが、型理論的には重要。
-        github_issue: null
+        github_issue: 176
         references:
           - docs/internal/requirements/20250101_0000_typeclass.yaml
 
@@ -188,7 +188,7 @@ priorities:
           async 関数を compose するためのマクロ。
           for_async! で部分的に対応済み。
           追加の async_compose! の需要は限定的。
-        github_issue: null
+        github_issue: 177
         references:
           - docs/internal/requirements/20250101_0100_compose.yaml
 
@@ -200,7 +200,7 @@ priorities:
           proc-macro で |> 演算子風の構文を提供する可能性の検討。
           Rust の構文制約により限定的。
           現在のマクロで十分な用途をカバー。
-        github_issue: null
+        github_issue: 178
         references:
           - docs/internal/requirements/20250101_0100_compose.yaml
 
@@ -212,7 +212,7 @@ priorities:
           PersistentTreeMap<T, ()> のラッパー。
           順序付きセット、範囲クエリのサポート。
           HashSet で代替可能な場合が多い。
-        github_issue: null
+        github_issue: 179
         references:
           - docs/internal/requirements/20250101_0300_persistent.yaml
 
@@ -224,7 +224,7 @@ priorities:
           Vec ではなくイテレータを返すバージョン。
           大量のデータを処理する場合に有用。
           現在の Vec 版で多くの用途をカバー。
-        github_issue: null
+        github_issue: 180
         references:
           - docs/internal/requirements/phase_10_1_for_macro.yaml
 
@@ -263,7 +263,7 @@ priorities:
           非同期コンテキストでの Optics 操作。
           async/await との統合。
           需要が限定的で、AsyncIO との統合で代替可能。
-        github_issue: null
+        github_issue: 181
         references:
           - docs/internal/requirements/20250101_0400_optics.yaml
 

--- a/docs/internal/issues/20260116_1500_bifunctor.yaml
+++ b/docs/internal/issues/20260116_1500_bifunctor.yaml
@@ -1,0 +1,75 @@
+# Issue: Bifunctor 型クラス
+# 二つの型パラメータを持つ型に対する Functor
+
+deferred_features:
+  - id: bifunctor
+    name: "Bifunctor 型クラス"
+    discovered_date: "2026-01-16"
+    priority: high
+    category: enhancement
+    labels:
+      - "typeclass"
+      - "enhancement"
+      - "priority: high"
+
+    problem:
+      summary: "Either/Result など二つの型パラメータを持つ型で bimap が使えない"
+      details: |
+        現在の lambars には Bifunctor 型クラスが存在しない。
+        Either<L, R> や Result<T, E> などの二項型で両方の型パラメータに
+        関数を適用する統一的な方法がない。
+
+        - 何が問題なのか: 二項型で両方の型を同時に変換する標準的な方法がない
+        - なぜ発生するのか: Functor は単一の型パラメータのみ対象
+        - どのような影響があるか: エラー処理パイプラインの構築が煩雑になる
+
+      rust_limitation: |
+        ```rust
+        // 現状: 手動で両方を変換する必要がある
+        let result: Either<String, i32> = either.map_left(|l| l.to_string())
+                                                 .map(|r| r + 1);
+
+        // 理想: bimap で一度に変換
+        let result = either.bimap(|l| l.to_string(), |r| r + 1);
+        ```
+
+    solution:
+      approach: "Bifunctor トレイトを定義し、Either, Result, Tuple に実装"
+      options:
+        - name: "標準的な Bifunctor トレイト"
+          description: |
+            Haskell/Scala 標準の Bifunctor を実装。
+            bimap, first, second メソッドを提供。
+          pros:
+            - "標準的な関数型言語との互換性"
+            - "エラー処理の簡潔化"
+            - "型クラス階層の拡充"
+          cons:
+            - "HKT の制約により Rust での表現が複雑になる可能性"
+
+        - name: "マクロベースの bimap"
+          description: |
+            トレイトではなくマクロで bimap を提供。
+          pros:
+            - "HKT の制約を回避"
+            - "実装が簡単"
+          cons:
+            - "型クラスとしての一貫性がない"
+            - "ジェネリックなコードで使いにくい"
+
+      recommended: "標準的な Bifunctor トレイト"
+      estimated_complexity: medium
+
+    references:
+      - "Haskell Data.Bifunctor"
+      - "Scala cats Bifunctor"
+      - "docs/internal/requirements/20250101_0000_typeclass.yaml"
+
+    related:
+      requirement_id: "typeclass"
+      plan_id: null
+
+    github_issue:
+      number: 170
+      url: "https://github.com/lihs-ie/lambars/issues/170"
+      created: true

--- a/docs/internal/issues/20260116_1501_alternative.yaml
+++ b/docs/internal/issues/20260116_1501_alternative.yaml
@@ -1,0 +1,79 @@
+# Issue: Alternative 型クラス
+# 選択と空を持つ Applicative の拡張
+
+deferred_features:
+  - id: alternative
+    name: "Alternative 型クラス"
+    discovered_date: "2026-01-16"
+    priority: high
+    category: enhancement
+    labels:
+      - "typeclass"
+      - "enhancement"
+      - "priority: high"
+
+    problem:
+      summary: "パーサーコンビネータ等で選択演算子 (<|>) と empty が使えない"
+      details: |
+        Alternative は Applicative を拡張し、選択（orElse）と
+        空の値（empty）を提供する型クラス。
+        パーサーコンビネータや非決定的計算で頻繁に使用される。
+
+        - 何が問題なのか: 選択を表す統一的な抽象がない
+        - なぜ発生するのか: Applicative の拡張として Alternative が未実装
+        - どのような影響があるか: nom や combine との連携が困難
+
+      rust_limitation: |
+        ```rust
+        // 現状: 各型で個別に or_else を実装
+        let opt1: Option<i32> = None;
+        let opt2: Option<i32> = Some(42);
+        let result = opt1.or(opt2);  // Option 固有
+
+        // 理想: Alternative トレイトで統一
+        fn try_parsers<F: Alternative>(p1: F, p2: F) -> F {
+            p1.or_else(p2)  // または p1 <|> p2 相当
+        }
+        ```
+
+    solution:
+      approach: "Alternative トレイトを Applicative の拡張として定義"
+      options:
+        - name: "Applicative 拡張としての Alternative"
+          description: |
+            Applicative を要求し、empty と or_else を追加。
+            Option, Vec, Result に実装。
+          pros:
+            - "型クラス階層の一貫性"
+            - "パーサーコンビネータとの相性が良い"
+            - "Haskell/Scala との互換性"
+          cons:
+            - "Applicative の実装が前提"
+            - "HKT の制約がある"
+
+        - name: "独立した Alternative トレイト"
+          description: |
+            Applicative に依存せず empty と or_else のみ定義。
+          pros:
+            - "シンプルな実装"
+            - "部分的な採用が可能"
+          cons:
+            - "型クラス階層との整合性がない"
+
+      recommended: "Applicative 拡張としての Alternative"
+      estimated_complexity: medium
+
+    references:
+      - "Haskell Control.Applicative (Alternative)"
+      - "Scala cats Alternative"
+      - "nom パーサーコンビネータ"
+      - "docs/internal/requirements/20250101_0000_typeclass.yaml"
+
+    related:
+      requirement_id: "typeclass"
+      plan_id: null
+
+    github_issue:
+      number: 171
+      url: "https://github.com/lihs-ie/lambars/issues/171"
+      created: true

--- a/docs/internal/issues/20260116_1502_freer_monad.yaml
+++ b/docs/internal/issues/20260116_1502_freer_monad.yaml
@@ -1,0 +1,85 @@
+# Issue: Freer モナド
+# Free モナドの最適化版、HKT 制約を回避
+
+deferred_features:
+  - id: freer_monad
+    name: "Freer モナド"
+    discovered_date: "2026-01-16"
+    priority: high
+    category: enhancement
+    labels:
+      - "control"
+      - "enhancement"
+      - "priority: high"
+
+    problem:
+      summary: "DSL 構築の基盤となる Freer モナドが未実装"
+      details: |
+        Freer モナドは Free モナドの最適化版で、Functor の代わりに
+        型レベルのリストを使用する。Rust では HKT の制約を回避できるため、
+        Free モナドより実装しやすい。
+
+        - 何が問題なのか: DSL を構築するための標準的な手段がない
+        - なぜ発生するのか: Freer モナドが未実装
+        - どのような影響があるか: 効果システムの拡張性が制限される
+
+      rust_limitation: |
+        ```rust
+        // Freer の基本構造
+        pub enum Freer<F, A> {
+            Pure(A),
+            Impure(F, Box<dyn FnOnce(?) -> Freer<F, A>>),
+        }
+
+        // 型レベルリストで効果を積み重ねる
+        // type Effects = Cons<State<i32>, Cons<Reader<Config>, Nil>>;
+        ```
+
+    solution:
+      approach: "型レベルリストを使用した Freer モナドを実装"
+      options:
+        - name: "frunk ベースの型レベルリスト"
+          description: |
+            frunk クレートの HList を使用して効果を積み重ねる。
+          pros:
+            - "既存のエコシステムを活用"
+            - "型安全"
+          cons:
+            - "外部依存が増える"
+            - "コンパイル時間への影響"
+
+        - name: "独自の型レベルリスト実装"
+          description: |
+            lambars 独自の型レベルリストを実装。
+          pros:
+            - "外部依存なし"
+            - "カスタマイズ可能"
+          cons:
+            - "実装コストが高い"
+
+        - name: "マクロベースの DSL"
+          description: |
+            proc-macro で DSL を生成。
+          pros:
+            - "柔軟性が高い"
+            - "エルゴノミクス重視"
+          cons:
+            - "型クラスとしての一貫性がない"
+
+      recommended: "独自の型レベルリスト実装"
+      estimated_complexity: high
+
+    references:
+      - "Freer Monads, More Extensible Effects (Oleg Kiselyov)"
+      - "extensible-effects (Haskell)"
+      - "cats-effect (Scala)"
+      - "docs/internal/requirements/20250101_0200_control.yaml"
+
+    related:
+      requirement_id: "control"
+      plan_id: null
+
+    github_issue:
+      number: 172
+      url: "https://github.com/lihs-ie/lambars/issues/172"
+      created: true

--- a/docs/internal/issues/20260116_1503_cont_transformer.yaml
+++ b/docs/internal/issues/20260116_1503_cont_transformer.yaml
@@ -1,0 +1,82 @@
+# Issue: ContT（Continuation Transformer）
+# 継続効果を追加するモナド変換子
+
+deferred_features:
+  - id: cont_transformer
+    name: "ContT（Continuation Transformer）"
+    discovered_date: "2026-01-16"
+    priority: medium
+    category: enhancement
+    labels:
+      - "effect"
+      - "control"
+      - "enhancement"
+      - "priority: medium"
+
+    problem:
+      summary: "継続効果を既存のモナドスタックに追加できない"
+      details: |
+        ContT は継続ベースの計算を他のモナドと組み合わせるための変換子。
+        callCC（call with current continuation）などの制御演算子を提供し、
+        高度な制御フロー（早期リターン、コルーチンなど）を実現する。
+
+        - 何が問題なのか: 継続を使った制御フローの抽象化がない
+        - なぜ発生するのか: Continuation モナドの変換子版が未実装
+        - どのような影響があるか: 複雑な制御フローの表現が困難
+
+        TrampolineT, ContinuationT もこの実装に統合予定。
+
+      rust_limitation: |
+        ```rust
+        // ContT の基本構造
+        pub struct ContT<R, M, A> {
+            run_cont: Box<dyn FnOnce(Box<dyn FnOnce(A) -> M<R>>) -> M<R>>,
+        }
+
+        // callCC: 現在の継続を取得
+        fn call_cc<R, M, A, B>(
+            f: impl FnOnce(Box<dyn FnOnce(A) -> ContT<R, M, B>>) -> ContT<R, M, A>
+        ) -> ContT<R, M, A>;
+        ```
+
+    solution:
+      approach: "既存の Continuation モナドをベースに変換子版を実装"
+      options:
+        - name: "Continuation ベースの ContT"
+          description: |
+            src/control/continuation.rs を拡張し、
+            変換子版を追加。MonadTrans トレイトを実装。
+          pros:
+            - "既存実装の活用"
+            - "型クラス階層との整合性"
+          cons:
+            - "HKT の制約で型が複雑になる"
+            - "ライフタイム管理が難しい"
+
+        - name: "単純化された ContT"
+          description: |
+            callCC のみサポートする簡易版。
+          pros:
+            - "実装が比較的簡単"
+            - "主要なユースケースをカバー"
+          cons:
+            - "完全な ContT の機能は提供しない"
+
+      recommended: "Continuation ベースの ContT"
+      estimated_complexity: high
+
+    references:
+      - "Haskell Control.Monad.Trans.Cont"
+      - "Scala cats ContT"
+      - "docs/internal/requirements/20250101_0500_effect.yaml"
+      - "docs/internal/requirements/20250101_0200_control.yaml"
+      - "src/control/continuation.rs"
+
+    related:
+      requirement_id: "effect"
+      plan_id: null
+
+    github_issue:
+      number: 173
+      url: "https://github.com/lihs-ie/lambars/issues/173"
+      created: true

--- a/docs/internal/issues/20260116_1504_select_transformer.yaml
+++ b/docs/internal/issues/20260116_1504_select_transformer.yaml
@@ -1,0 +1,79 @@
+# Issue: SelectT（Selection Transformer）
+# 非決定的選択を扱うモナド変換子
+
+deferred_features:
+  - id: select_transformer
+    name: "SelectT（Selection Transformer）"
+    discovered_date: "2026-01-16"
+    priority: medium
+    category: enhancement
+    labels:
+      - "effect"
+      - "enhancement"
+      - "priority: medium"
+
+    problem:
+      summary: "バックトラッキングや非決定的選択の抽象化がない"
+      details: |
+        SelectT は非決定的選択（選択関数）を扱う変換子。
+        バックトラッキング、ゲーム木探索、AI アルゴリズムなどで有用。
+        select 操作で「最適な」選択を表現できる。
+
+        - 何が問題なのか: 非決定的選択を抽象化する手段がない
+        - なぜ発生するのか: SelectT モナド変換子が未実装
+        - どのような影響があるか: 探索アルゴリズムの表現が冗長になる
+
+      rust_limitation: |
+        ```rust
+        // SelectT の基本構造
+        pub struct SelectT<R, M, A> {
+            run_select: Box<dyn FnOnce(Box<dyn Fn(A) -> R>) -> M<A>>,
+        }
+
+        // select: 評価関数を使って最適な値を選択
+        fn select<R, M, A>(
+            sel: impl Fn(Box<dyn Fn(A) -> R>) -> A
+        ) -> SelectT<R, M, A>;
+        ```
+
+    solution:
+      approach: "ContT の実装後、SelectT を ContT をベースに構築"
+      options:
+        - name: "ContT ベースの SelectT"
+          description: |
+            ContT を内部で使用し SelectT を実装。
+            MonadTrans トレイトを実装。
+          pros:
+            - "ContT の再利用"
+            - "理論的な基盤がしっかり"
+          cons:
+            - "ContT への依存"
+            - "複雑な型シグネチャ"
+
+        - name: "独立した SelectT 実装"
+          description: |
+            ContT に依存せず独自に実装。
+          pros:
+            - "依存関係がシンプル"
+          cons:
+            - "コードの重複"
+            - "理論的整合性が低い"
+
+      recommended: "ContT ベースの SelectT"
+      estimated_complexity: high
+
+    references:
+      - "Haskell Control.Monad.Trans.Select"
+      - "Selection Functions, Bar Recursion and Backward Induction"
+      - "docs/internal/requirements/20250101_0500_effect.yaml"
+
+    related:
+      requirement_id: "effect"
+      plan_id: null
+    dependencies:
+      - "cont_transformer"  # FW-005: ContT の実装が前提
+
+    github_issue:
+      number: 174
+      url: "https://github.com/lihs-ie/lambars/issues/174"
+      created: true

--- a/docs/internal/issues/20260116_1505_persistent_optics_integration.yaml
+++ b/docs/internal/issues/20260116_1505_persistent_optics_integration.yaml
@@ -1,0 +1,78 @@
+# Issue: Lens/Prism と永続データ構造の統合強化
+# optics と persistent モジュールの連携強化
+
+deferred_features:
+  - id: persistent_optics_integration
+    name: "Lens/Prism と永続データ構造の統合強化"
+    discovered_date: "2026-01-16"
+    priority: medium
+    category: enhancement
+    labels:
+      - "optics"
+      - "persistent"
+      - "enhancement"
+      - "priority: medium"
+
+    problem:
+      summary: "永続データ構造への深いアクセスと不変更新が煩雑"
+      details: |
+        現在 optics と persistent モジュールは独立して存在するが、
+        より深い統合により、永続データ構造への効率的なアクセスと
+        更新が可能になる。
+
+        - 何が問題なのか: 深くネストした永続構造の更新が冗長
+        - なぜ発生するのか: optics と persistent の連携が限定的
+        - どのような影響があるか: 複雑なデータ構造の操作が面倒
+
+      rust_limitation: |
+        ```rust
+        // 現状: 手動でネストを辿る
+        let new_map = map.update(&key1, |inner| {
+            inner.update(&key2, |value| value + 1)
+        });
+
+        // 理想: Lens を使って一行で
+        let new_map = map.over(at(key1).then(at(key2)), |v| v + 1);
+        ```
+
+    solution:
+      approach: "persistent_optics.rs を拡張し、より多くの連携機能を追加"
+      options:
+        - name: "At/Index トレイトの拡張"
+          description: |
+            At, Ixed トレイトの永続データ構造向け最適化実装を追加。
+            効率的な部分更新をサポート。
+          pros:
+            - "既存の optics トレイトを活用"
+            - "一貫した API"
+          cons:
+            - "パフォーマンスチューニングが必要"
+
+        - name: "専用の PersistentLens"
+          description: |
+            永続データ構造専用の Lens バリアントを作成。
+            構造共有を最大化。
+          pros:
+            - "最適化の余地が大きい"
+            - "構造共有を意識した設計"
+          cons:
+            - "API の複雑化"
+            - "学習コストの増加"
+
+      recommended: "At/Index トレイトの拡張"
+      estimated_complexity: medium
+
+    references:
+      - "src/optics/persistent_optics.rs"
+      - "src/optics/at.rs"
+      - "src/optics/ixed.rs"
+      - "docs/internal/requirements/20250101_0300_persistent.yaml"
+
+    related:
+      requirement_id: "persistent"
+      plan_id: null
+
+    github_issue:
+      number: 175
+      url: "https://github.com/lihs-ie/lambars/issues/175"
+      created: true

--- a/docs/internal/issues/20260116_1506_contravariant.yaml
+++ b/docs/internal/issues/20260116_1506_contravariant.yaml
@@ -1,0 +1,78 @@
+# Issue: Contravariant 型クラス
+# 反変ファンクター
+
+deferred_features:
+  - id: contravariant
+    name: "Contravariant 型クラス"
+    discovered_date: "2026-01-16"
+    priority: low
+    category: enhancement
+    labels:
+      - "typeclass"
+      - "enhancement"
+      - "priority: low"
+
+    problem:
+      summary: "入力の型に対する反変マッピング（contramap）がない"
+      details: |
+        Contravariant は Functor の双対で、入力の型に対して
+        contramap を持つ。Predicate、Comparator、Serializer などで有用。
+
+        - 何が問題なのか: 反変ファンクターの抽象がない
+        - なぜ発生するのか: Contravariant 型クラスが未実装
+        - どのような影響があるか: 述語やシリアライザの合成が不便
+
+      rust_limitation: |
+        ```rust
+        // Contravariant の定義
+        trait Contravariant<A> {
+            type Target<B>;
+            fn contramap<B>(self, f: impl Fn(B) -> A) -> Self::Target<B>;
+        }
+
+        // 使用例: Predicate
+        struct Predicate<A>(Box<dyn Fn(&A) -> bool>);
+
+        impl<A> Contravariant<A> for Predicate<A> {
+            type Target<B> = Predicate<B>;
+            fn contramap<B>(self, f: impl Fn(B) -> A) -> Predicate<B> {
+                Predicate(Box::new(move |b| (self.0)(&f(b.clone()))))
+            }
+        }
+
+        // 使用例
+        let is_positive: Predicate<i32> = Predicate(Box::new(|x| *x > 0));
+        let string_len_positive: Predicate<String> =
+            is_positive.contramap(|s: String| s.len() as i32);
+        ```
+
+    solution:
+      approach: "Contravariant トレイトを定義し、Predicate 等に実装"
+      options:
+        - name: "標準的な Contravariant"
+          description: |
+            contramap メソッドを持つトレイトを定義。
+            Predicate, Comparator, Serializer に実装。
+          pros:
+            - "型理論的に正しい"
+            - "Haskell/Scala との互換性"
+          cons:
+            - "使用頻度が低い"
+            - "HKT の制約"
+
+      recommended: "標準的な Contravariant"
+      estimated_complexity: medium
+
+    references:
+      - "Haskell Data.Functor.Contravariant"
+      - "Scala cats Contravariant"
+      - "docs/internal/requirements/20250101_0000_typeclass.yaml"
+
+    related:
+      requirement_id: "typeclass"
+      plan_id: null
+
+    github_issue:
+      number: 176
+      url: "https://github.com/lihs-ie/lambars/issues/176"
+      created: true

--- a/docs/internal/issues/20260116_1507_async_compose.yaml
+++ b/docs/internal/issues/20260116_1507_async_compose.yaml
@@ -1,0 +1,78 @@
+# Issue: async 関数の合成（async_compose!）
+# 非同期関数を合成するマクロ
+
+deferred_features:
+  - id: async_compose
+    name: "async 関数の合成（async_compose!）"
+    discovered_date: "2026-01-16"
+    priority: low
+    category: enhancement
+    labels:
+      - "compose"
+      - "async"
+      - "enhancement"
+      - "priority: low"
+
+    problem:
+      summary: "async 関数を compose! マクロで合成できない"
+      details: |
+        現在の compose! マクロは同期関数のみ対応。
+        async 関数を合成するには手動で .await を挟む必要がある。
+
+        - 何が問題なのか: async 関数の合成が煩雑
+        - なぜ発生するのか: compose! が async 非対応
+        - どのような影響があるか: 非同期パイプラインの構築が面倒
+
+        ただし for_async! マクロで部分的に対応済み。
+
+      rust_limitation: |
+        ```rust
+        // 現状: 手動で await を挟む
+        async fn pipeline(x: i32) -> String {
+            let a = fetch_data(x).await;
+            let b = process(a).await;
+            format_result(b).await
+        }
+
+        // 理想: async_compose! で合成
+        let pipeline = async_compose!(fetch_data, process, format_result);
+        ```
+
+    solution:
+      approach: "async_compose! マクロを追加"
+      options:
+        - name: "async_compose! マクロ"
+          description: |
+            async 関数を合成する専用マクロ。
+            内部で .await を自動挿入。
+          pros:
+            - "for_async! との一貫性"
+            - "非同期パイプラインの簡潔化"
+          cons:
+            - "エラー処理との組み合わせが複雑"
+            - "for_async! で代替可能な場合が多い"
+
+        - name: "for_async! の拡張"
+          description: |
+            既存の for_async! を拡張して関数合成をサポート。
+          pros:
+            - "既存マクロの活用"
+            - "学習コスト削減"
+          cons:
+            - "マクロの複雑化"
+
+      recommended: "async_compose! マクロ"
+      estimated_complexity: medium
+
+    references:
+      - "src/compose/for_async.rs"
+      - "docs/internal/requirements/20250101_0100_compose.yaml"
+
+    related:
+      requirement_id: "compose"
+      plan_id: null
+
+    github_issue:
+      number: 177
+      url: "https://github.com/lihs-ie/lambars/issues/177"
+      created: true

--- a/docs/internal/issues/20260116_1508_pipeline_operator.yaml
+++ b/docs/internal/issues/20260116_1508_pipeline_operator.yaml
@@ -1,0 +1,81 @@
+# Issue: パイプライン演算子のカスタム構文
+# |> 演算子風の構文を提供
+
+deferred_features:
+  - id: pipeline_operator
+    name: "パイプライン演算子のカスタム構文"
+    discovered_date: "2026-01-16"
+    priority: low
+    category: enhancement
+    labels:
+      - "compose"
+      - "enhancement"
+      - "priority: low"
+
+    problem:
+      summary: "Elixir/F# のような |> パイプライン演算子がない"
+      details: |
+        Rust では演算子のオーバーロードが制限されており、
+        |> のようなカスタム演算子を定義できない。
+        proc-macro でエミュレートする可能性を検討。
+
+        - 何が問題なのか: パイプライン演算子による読みやすい構文がない
+        - なぜ発生するのか: Rust の演算子制約
+        - どのような影響があるか: 関数チェーンの可読性が低下
+
+        ただし現在のマクロ（pipe!, compose!）で十分な用途をカバー。
+
+      rust_limitation: |
+        ```rust
+        // Rust では |> 演算子を定義できない
+        // 以下は構文エラー
+        // let result = x |> f |> g |> h;
+
+        // 現在の代替: pipe! マクロ
+        let result = pipe!(x => f => g => h);
+
+        // または compose! + 適用
+        let pipeline = compose!(f, g, h);
+        let result = pipeline(x);
+        ```
+
+    solution:
+      approach: "proc-macro で演算子風構文をエミュレート"
+      options:
+        - name: "pipe! マクロの拡張"
+          description: |
+            既存の pipe! マクロをより |> に近い構文に改善。
+          pros:
+            - "既存実装の活用"
+            - "破壊的変更なし"
+          cons:
+            - "本物の演算子ではない"
+            - "IDE サポートが限定的"
+
+        - name: "proc-macro で |> をエミュレート"
+          description: |
+            proc-macro で `|>` トークンを認識し変換。
+          pros:
+            - "見た目が本物に近い"
+          cons:
+            - "Rust の構文規則に反する"
+            - "メンテナンスコストが高い"
+            - "エラーメッセージが分かりにくい"
+
+      recommended: "pipe! マクロの拡張"
+      estimated_complexity: low
+
+    references:
+      - "Elixir |> operator"
+      - "F# |> operator"
+      - "src/compose/pipe.rs"
+      - "docs/internal/requirements/20250101_0100_compose.yaml"
+
+    related:
+      requirement_id: "compose"
+      plan_id: null
+
+    github_issue:
+      number: 178
+      url: "https://github.com/lihs-ie/lambars/issues/178"
+      created: true

--- a/docs/internal/issues/20260116_1509_persistent_treeset.yaml
+++ b/docs/internal/issues/20260116_1509_persistent_treeset.yaml
@@ -1,0 +1,80 @@
+# Issue: Persistent TreeSet
+# 順序付き永続セット
+
+deferred_features:
+  - id: persistent_treeset
+    name: "Persistent TreeSet"
+    discovered_date: "2026-01-16"
+    priority: low
+    category: enhancement
+    labels:
+      - "persistent"
+      - "enhancement"
+      - "priority: low"
+
+    problem:
+      summary: "順序付きの永続セットがない"
+      details: |
+        PersistentHashSet は存在するが、要素の順序を保持しない。
+        範囲クエリや順序付きイテレーションが必要な場合に不便。
+
+        - 何が問題なのか: 順序付き永続セットがない
+        - なぜ発生するのか: TreeSet が未実装
+        - どのような影響があるか: 範囲クエリ等ができない
+
+        ただし HashSet で代替可能な場合が多い。
+
+      rust_limitation: |
+        ```rust
+        // 現状: HashSet は順序なし
+        let set: PersistentHashSet<i32> = [3, 1, 4, 1, 5].into();
+        // イテレーションの順序は不定
+
+        // 理想: TreeSet で順序保持
+        let set: PersistentTreeSet<i32> = [3, 1, 4, 1, 5].into();
+        // イテレーションは 1, 3, 4, 5 の順
+
+        // 範囲クエリ
+        let range: Vec<i32> = set.range(2..5).collect(); // [3, 4]
+        ```
+
+    solution:
+      approach: "PersistentTreeMap<T, ()> のラッパーとして実装"
+      options:
+        - name: "TreeMap ラッパー"
+          description: |
+            PersistentTreeMap<T, ()> をラップして TreeSet を実装。
+            API を Set に合わせて提供。
+          pros:
+            - "実装が簡単"
+            - "TreeMap のテスト済みコードを再利用"
+          cons:
+            - "メモリオーバーヘッド（() の分）"
+            - "間接参照のコスト"
+
+        - name: "専用の TreeSet 実装"
+          description: |
+            B-Tree ベースの専用 TreeSet を実装。
+          pros:
+            - "最適化の余地"
+            - "メモリ効率"
+          cons:
+            - "実装コストが高い"
+            - "コードの重複"
+
+      recommended: "TreeMap ラッパー"
+      estimated_complexity: low
+
+    references:
+      - "src/persistent/treemap.rs"
+      - "src/persistent/hashset.rs"
+      - "docs/internal/requirements/20250101_0300_persistent.yaml"
+
+    related:
+      requirement_id: "persistent"
+      plan_id: null
+
+    github_issue:
+      number: 179
+      url: "https://github.com/lihs-ie/lambars/issues/179"
+      created: true

--- a/docs/internal/issues/20260116_1510_for_iter_lazy.yaml
+++ b/docs/internal/issues/20260116_1510_for_iter_lazy.yaml
@@ -1,0 +1,88 @@
+# Issue: 遅延イテレータ版 for_iter!
+# Vec ではなくイテレータを返すバージョン
+
+deferred_features:
+  - id: for_iter_lazy
+    name: "遅延イテレータ版 for_iter!"
+    discovered_date: "2026-01-16"
+    priority: low
+    category: enhancement
+    labels:
+      - "compose"
+      - "macro"
+      - "enhancement"
+      - "priority: low"
+
+    problem:
+      summary: "for_iter! が Vec を返すため大量データで非効率"
+      details: |
+        現在の for_iter! は結果を Vec に収集して返す。
+        大量のデータを処理する場合、全要素をメモリに保持するため非効率。
+
+        - 何が問題なのか: 大量データで中間 Vec が生成される
+        - なぜ発生するのか: for_iter! が Vec を返す設計
+        - どのような影響があるか: メモリ使用量の増加、パフォーマンス低下
+
+        ただし現在の Vec 版で多くの用途をカバーしている。
+
+      rust_limitation: |
+        ```rust
+        // 現状: Vec を返す
+        let results: Vec<i32> = for_iter!(
+            x <- vec![1, 2, 3, 4, 5];
+            y <- vec![10, 20];
+            yield x + y
+        ); // Vec<i32> が即座に生成される
+
+        // 理想: 遅延イテレータを返す
+        let results = for_iter_lazy!(
+            x <- vec![1, 2, 3, 4, 5];
+            y <- vec![10, 20];
+            yield x + y
+        ); // impl Iterator<Item = i32> を返す
+
+        // 必要な分だけ評価
+        for r in results.take(3) {
+            println!("{}", r);
+        }
+        ```
+
+    solution:
+      approach: "for_iter_lazy! マクロを追加し遅延イテレータを返す"
+      options:
+        - name: "for_iter_lazy! マクロ"
+          description: |
+            遅延評価版のマクロを追加。
+            impl Iterator を返す。
+          pros:
+            - "大量データに対応"
+            - "メモリ効率の向上"
+          cons:
+            - "ライフタイムの複雑化"
+            - "デバッグが難しい"
+
+        - name: "for_iter! にオプション追加"
+          description: |
+            for_iter! にフラグを追加して遅延/即時を選択。
+          pros:
+            - "単一マクロで統一"
+          cons:
+            - "マクロの複雑化"
+            - "構文が分かりにくくなる"
+
+      recommended: "for_iter_lazy! マクロ"
+      estimated_complexity: medium
+
+    references:
+      - "src/compose/for_macro.rs"
+      - "docs/internal/requirements/phase_10_1_for_macro.yaml"
+      - "Haskell list comprehension（遅延評価）"
+
+    related:
+      requirement_id: "compose"
+      plan_id: null
+
+    github_issue:
+      number: 180
+      url: "https://github.com/lihs-ie/lambars/issues/180"
+      created: true

--- a/docs/internal/issues/20260116_1511_async_optics.yaml
+++ b/docs/internal/issues/20260116_1511_async_optics.yaml
@@ -1,0 +1,80 @@
+# Issue: Async Optics
+# 非同期コンテキストでの Optics 操作
+
+deferred_features:
+  - id: async_optics
+    name: "Async Optics"
+    discovered_date: "2026-01-16"
+    priority: low
+    category: research
+    labels:
+      - "optics"
+      - "async"
+      - "research"
+      - "priority: low"
+
+    problem:
+      summary: "非同期コンテキストで Lens/Prism を使えない"
+      details: |
+        現在の Optics は同期的な操作のみサポート。
+        非同期のゲッター/セッターを使う場合、手動で await を挟む必要がある。
+
+        - 何が問題なのか: async fn を使った Lens 操作ができない
+        - なぜ発生するのか: Optics が async 非対応
+        - どのような影響があるか: 非同期データソースへのアクセスが煩雑
+
+        需要が限定的で、AsyncIO との統合で代替可能な場合が多い。
+
+      rust_limitation: |
+        ```rust
+        // 現状: async getter/setter を手動で扱う
+        async fn get_nested_value(data: &AsyncData) -> i32 {
+            let outer = data.fetch_outer().await;
+            let inner = outer.fetch_inner().await;
+            inner.value
+        }
+
+        // 理想: async Lens で一行
+        let value = async_lens!(outer, inner, value).get_async(data).await;
+        ```
+
+    solution:
+      approach: "Optics トレイトに async バリアントを追加（将来検討）"
+      options:
+        - name: "AsyncLens トレイト"
+          description: |
+            Lens の async 版トレイトを定義。
+            get_async, set_async メソッドを提供。
+          pros:
+            - "非同期データソースに対応"
+            - "型安全"
+          cons:
+            - "トレイトの複雑化"
+            - "async trait の制約"
+            - "需要が限定的"
+
+        - name: "AsyncIO + 既存 Optics の組み合わせ"
+          description: |
+            AsyncIO で非同期を扱い、内部では既存 Optics を使用。
+          pros:
+            - "既存実装の活用"
+            - "効果システムとの統合"
+          cons:
+            - "やや冗長"
+
+      recommended: "AsyncIO + 既存 Optics の組み合わせ"
+      estimated_complexity: high
+
+    references:
+      - "src/optics/"
+      - "src/effect/async_io.rs"
+      - "docs/internal/requirements/20250101_0400_optics.yaml"
+
+    related:
+      requirement_id: "optics"
+      plan_id: null
+
+    github_issue:
+      number: 181
+      url: "https://github.com/lihs-ie/lambars/issues/181"
+      created: true


### PR DESCRIPTION
## Summary

- 要件定義ファイルから 16 件の future_work 項目を抽出
- P1（高）、P2（中）、P3（低）、P4（将来）に優先度分類
- 既に実装済みの 14 項目をドキュメント化
- Codex レビューによる優先度調整：
  - Freer モナドを P1 に（Rust では Free より実装しやすい）
  - Alternative を P1 に（パーサー等で即効性あり）
  - ContinuationT を ContT に統合（重複解消）
  - SelectT に ContT への依存を明記

## Test plan

- [x] YAML ファイルのフォーマット確認
- [x] Codex によるレビュー完了
- [x] pre-commit hooks パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)