### PR TITLE
perf: Enable LTO and add SmallVec dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "smallvec",
  "static_assertions",
  "tokio",
  "trybuild",
@@ -928,6 +929,12 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 rayon = { version = "1.10", optional = true }
 paste = "1.0"
 static_assertions = "1.1"
+smallvec = { version = "1.13", features = ["const_generics"] }
 
 [dev-dependencies]
 rstest = "^0.26"
@@ -139,5 +140,11 @@ name = "iai_benchmark_validation"
 path = "tests/iai_benchmark_validation.rs"
 required-features = ["typeclass", "control", "persistent", "optics", "effect", "compose"]
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+opt-level = 3
+
 [profile.bench]
+inherits = "release"
 debug = true  # Required for Iai-Callgrind


### PR DESCRIPTION
## Summary
パフォーマンス大改善計画の Phase 0（基盤整備）です。

### 変更内容
- **LTO (Link-Time Optimization) 有効化**
  - `[profile.release]` に `lto = "fat"`, `codegen-units = 1`, `opt-level = 3` を追加
  - `[profile.bench]` を release から継承するよう変更
  
- **SmallVec 依存追加**
  - `smallvec = { version = "1.13", features = ["const_generics"] }` を追加
  - Phase 1 (TreeMap最適化) で使用予定

### 期待改善
- LTO により全体で 10-20% のパフォーマンス改善

## Test plan
- [x] `cargo check --all-features` が通ること
- [x] `cargo clippy --all-features --all-targets -- -D warnings` が通ること
- [ ] CI でベンチマークが実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)