### PR TITLE
fix(ci): dynamically resolve iai-callgrind-runner version

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -39,6 +39,15 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Checkout PR branch first (to get Cargo.lock)
+        uses: actions/checkout@v4
+
+      - name: Get iai-callgrind version
+        id: iai-version
+        run: |
+          IAI_VERSION=$(grep -A1 'name = "iai-callgrind"' Cargo.lock | grep version | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "version=$IAI_VERSION" >> $GITHUB_OUTPUT
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -53,12 +62,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-bin-iai-callgrind-runner-0.14.2
+          key: ${{ runner.os }}-cargo-bin-iai-callgrind-runner-${{ steps.iai-version.outputs.version }}
 
       - name: Install iai-callgrind-runner
         run: |
           if ! command -v iai-callgrind-runner &> /dev/null; then
-            cargo install iai-callgrind-runner --version 0.14.2
+            cargo install iai-callgrind-runner --version ${{ steps.iai-version.outputs.version }}
           fi
 
       - name: Cache cargo registry

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,16 +40,22 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y valgrind
 
+      - name: Get iai-callgrind version
+        id: iai-version
+        run: |
+          IAI_VERSION=$(grep -A1 'name = "iai-callgrind"' Cargo.lock | grep version | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "version=$IAI_VERSION" >> $GITHUB_OUTPUT
+
       - name: Cache cargo bin
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-bin-iai-callgrind-runner-0.14.2
+          key: ${{ runner.os }}-cargo-bin-iai-callgrind-runner-${{ steps.iai-version.outputs.version }}
 
       - name: Install iai-callgrind-runner
         run: |
           if ! command -v iai-callgrind-runner &> /dev/null; then
-            cargo install iai-callgrind-runner --version 0.14.2
+            cargo install iai-callgrind-runner --version ${{ steps.iai-version.outputs.version }}
           fi
 
       - name: Cache cargo registry and target

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -135,7 +135,11 @@ jobs:
           sudo apt-get install -y valgrind
 
       - name: Install iai-callgrind-runner
-        run: cargo install iai-callgrind-runner --version 0.14.0
+        run: |
+          # Get iai-callgrind version from Cargo.lock to ensure version match
+          IAI_VERSION=$(grep -A1 'name = "iai-callgrind"' Cargo.lock | grep version | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "Installing iai-callgrind-runner version $IAI_VERSION"
+          cargo install iai-callgrind-runner --version "$IAI_VERSION"
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/docs/internal/done/issues/20260120_0920_iai_callgrind_version_mismatch.yaml
+++ b/docs/internal/done/issues/20260120_0920_iai_callgrind_version_mismatch.yaml
@@ -1,0 +1,73 @@
+# Issue: iai-callgrind-runner バージョン不一致の修正
+# CIで発生しているエラーの修正
+
+deferred_features:
+  - id: iai_callgrind_version_mismatch
+    name: "iai-callgrind-runner バージョン不一致の修正"
+    discovered_date: "2026-01-20"
+    priority: high
+    category: bug
+    labels:
+      - "bug"
+      - "performance"
+
+    problem:
+      summary: "iai-callgrind-runner (0.14.0) と iai-callgrind (0.14.2) のバージョン不一致でベンチマークが実行されない"
+      details: |
+        GitHub Actions run #21154282399 のプロファイリングワークフローで、
+        iai-callgrind ベンチマークがバージョン不一致エラーで実行されていない。
+
+        ## エラー内容
+        ```
+        iai_callgrind_runner: Error: iai-callgrind-runner (0.14.0) is older than
+        iai-callgrind (0.14.2). Please update iai-callgrind-runner by calling
+        'cargo install --version 0.14.2 iai-callgrind-runner'
+        ```
+
+        ## 影響を受けるベンチマーク
+        - effect_iai
+        - persistent_vector_iai
+        - scenario_iai
+
+        ## 影響
+        iai-callgrindベンチマークが実行されないため、
+        命令数レベルでの詳細なパフォーマンス分析ができない。
+
+    solution:
+      approach: "CI設定でiai-callgrind-runnerのバージョンを明示的に指定"
+      options:
+        - name: "固定バージョン指定"
+          description: |
+            CI設定で `cargo install --version 0.14.2 iai-callgrind-runner` を実行
+          pros:
+            - シンプルで確実
+            - 即座に修正可能
+          cons:
+            - ライブラリ更新時に手動でCIも更新が必要
+
+        - name: "動的バージョン取得"
+          description: |
+            cargo metadataからiai-callgrindのバージョンを取得し、
+            同じバージョンのrunnerをインストール
+          pros:
+            - ライブラリ更新時に自動追従
+            - メンテナンスフリー
+          cons:
+            - 実装が複雑
+            - jqなどの追加ツールが必要
+
+      recommended: "動的バージョン取得"
+      estimated_complexity: low
+
+    references:
+      - "https://github.com/lihs-ie/lambars/actions/runs/21154282399"
+      - "https://github.com/iai-callgrind/iai-callgrind"
+
+    related:
+      requirement_id: null
+      plan_id: null
+
+    github_issue:
+      number: 212
+      url: "https://github.com/lihs-ie/lambars/issues/212"
+      created: true


### PR DESCRIPTION
Fixed version mismatch between iai-callgrind (0.14.2) and iai-callgrind-runner (0.14.0) that caused iai benchmarks to fail.

Changes:
- profiling.yml: Extract version from Cargo.lock
- benchmark.yml: Use GitHub Actions output for version sharing
- benchmark-pr.yml: Checkout PR branch first to get Cargo.lock

Closes #212

## Summary

<!-- Briefly describe what this PR does -->

## Changes

<!-- List the main changes -->

-

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" -->

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] My code follows the project's coding style
- [ ] I have run `cargo fmt`
- [ ] I have run `cargo clippy --all-features --all-targets -- -D warnings`
- [ ] I have run `cargo test --no-default-features`
- [ ] I have run `cargo test --all-features`
- [ ] I have run `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Test Plan

<!-- Describe how you tested these changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
