### PR TITLE
fix(ci): update iai-callgrind-runner for PR branch version changes

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -99,6 +99,22 @@ jobs:
         with:
           clean: false
 
+      - name: Update iai-callgrind-runner for PR branch if needed
+        run: |
+          # Get iai-callgrind version from PR branch's Cargo.lock
+          PR_IAI_VERSION=$(grep -A1 'name = "iai-callgrind"' Cargo.lock | grep version | head -1 | sed 's/.*"\(.*\)"/\1/')
+          INSTALLED_VERSION=$(iai-callgrind-runner --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "none")
+
+          echo "PR branch iai-callgrind version: $PR_IAI_VERSION"
+          echo "Installed runner version: $INSTALLED_VERSION"
+
+          if [ "$PR_IAI_VERSION" != "$INSTALLED_VERSION" ]; then
+            echo "Version mismatch detected. Installing iai-callgrind-runner $PR_IAI_VERSION"
+            cargo install iai-callgrind-runner --version "$PR_IAI_VERSION" --force
+          else
+            echo "Runner version matches, no update needed"
+          fi
+
       - name: Run PR benchmarks with baseline comparison
         if: steps.check-benchmarks.outputs.benchmarks_exist == 'true'
         run: |


### PR DESCRIPTION
## Summary

- PRブランチでiai-callgrindのバージョンが変更された場合（Dependabotの更新など）、mainブランチのCargo.lockに基づいてインストールされたrunnerバージョンがPRのCargo.lockと一致しない問題を修正
- PRブランチをチェックアウトした後にrunnerのバージョンをチェックし、必要に応じて更新するステップを追加

## 背景

PR #204 (Dependabot: iai-callgrind 0.14.2 → 0.16.1) のCIが以下のエラーで失敗:
```
iai_callgrind_runner: Error: iai-callgrind-runner (0.14.2) is older than iai-callgrind (0.16.1)
```

## Test plan

- [ ] このPRがマージされた後、PR #204 を再実行してCIがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)