### PR TITLE
perf(bench): add phase-aware threshold evaluation for profiling scenarios

### DIFF
--- a/benches/api/benchmarks/check_thresholds.sh
+++ b/benches/api/benchmarks/check_thresholds.sh
@@ -79,15 +79,12 @@ check_rps_threshold() {
         return 0
     fi
 
+    # Prefer phase_metrics[$metric] if present; fall back to results.rps (merged).
     local actual_rps
     actual_rps=$(jq -r \
         --arg metric "${rps_metric}" \
-        '.results.phase_metrics[$metric] // .results.rps // empty' \
+        '(.results.phase_metrics[$metric] // .results.rps) // empty' \
         "${meta_file}" 2>/dev/null || true)
-
-    if [[ -z "${actual_rps}" ]] || [[ "${actual_rps}" == "null" ]]; then
-        actual_rps=$(jq -r '.results.rps // empty' "${meta_file}" 2>/dev/null || true)
-    fi
 
     if [[ -z "${actual_rps}" ]] || [[ "${actual_rps}" == "null" ]]; then
         echo "WARNING: RPS metric '${rps_metric}' not found in meta.json; skipping RPS threshold check"

--- a/benches/api/benchmarks/check_thresholds.sh
+++ b/benches/api/benchmarks/check_thresholds.sh
@@ -31,8 +31,7 @@ get_threshold() {
     esac
 
     local value
-    value=$(SCENARIO_NAME="${scenario}" METRIC_KEY="${yaml_key}" \
-        yq '.scenarios[env(SCENARIO_NAME)][env(METRIC_KEY)].error // ""' \
+    value=$(yq ".scenarios.${scenario}[\"${yaml_key}\"].error // \"\"" \
         "${yaml_file}" 2>/dev/null || true)
     if [[ -n "${value}" && "${value}" != "null" ]]; then
         echo "${value}"
@@ -51,8 +50,7 @@ get_rps_rule() {
     fi
 
     local value
-    value=$(SCENARIO_NAME="${scenario}" RPS_FIELD="${field}" \
-        yq '.scenarios[env(SCENARIO_NAME)].rps[env(RPS_FIELD)] // ""' \
+    value=$(yq ".scenarios.${scenario}.rps.${field} // \"\"" \
         "${yaml_file}" 2>/dev/null || true)
     if [[ -n "${value}" && "${value}" != "null" ]]; then
         echo "${value}"

--- a/benches/api/benchmarks/check_thresholds.sh
+++ b/benches/api/benchmarks/check_thresholds.sh
@@ -17,31 +17,27 @@ get_threshold() {
 
     if [[ ! -f "${yaml_file}" ]]; then
         echo ""
-        return
+        return 0
     fi
 
     local yaml_key
     case "${metric}" in
-        p50|p90|p99)
-            yaml_key="${metric}_latency_ms"
-            ;;
-        error_rate|conflict_rate)
-            yaml_key="${metric}"
-            ;;
+        p50|p90|p99)              yaml_key="${metric}_latency_ms" ;;
+        error_rate|conflict_rate) yaml_key="${metric}" ;;
         *)
             echo ""
-            return
+            return 0
             ;;
     esac
 
     local value
     value=$(SCENARIO_NAME="${scenario}" METRIC_KEY="${yaml_key}" \
         yq '.scenarios[env(SCENARIO_NAME)][env(METRIC_KEY)].error // ""' \
-        "${yaml_file}" 2>/dev/null)
-
-    if [[ -n "${value}" ]] && [[ "${value}" != "null" ]]; then
+        "${yaml_file}" 2>/dev/null || true)
+    if [[ -n "${value}" && "${value}" != "null" ]]; then
         echo "${value}"
     fi
+    return 0
 }
 
 get_rps_rule() {
@@ -51,26 +47,24 @@ get_rps_rule() {
 
     if [[ ! -f "${yaml_file}" ]]; then
         echo ""
-        return
+        return 0
     fi
 
     local value
     value=$(SCENARIO_NAME="${scenario}" RPS_FIELD="${field}" \
         yq '.scenarios[env(SCENARIO_NAME)].rps[env(RPS_FIELD)] // ""' \
-        "${yaml_file}" 2>/dev/null)
-
-    if [[ -n "${value}" ]] && [[ "${value}" != "null" ]]; then
+        "${yaml_file}" 2>/dev/null || true)
+    if [[ -n "${value}" && "${value}" != "null" ]]; then
         echo "${value}"
     fi
+    return 0
 }
 
 check_rps_threshold() {
     local meta_file="${1}"
     local scenario="${2}"
 
-    local rps_metric
-    local rps_warning
-    local rps_error
+    local rps_metric rps_warning rps_error
     rps_metric=$(get_rps_rule "${scenario}" "metric")
     rps_warning=$(get_rps_rule "${scenario}" "warning")
     rps_error=$(get_rps_rule "${scenario}" "error")

--- a/benches/api/benchmarks/run_benchmark.sh
+++ b/benches/api/benchmarks/run_benchmark.sh
@@ -1438,7 +1438,7 @@ compute_error_rate() {
 #   - steady:       actual_rps of the "main" phase (fallback: weighted_rps)
 #   - ramp_up_down: actual_rps of the "sustain" phase (fallback: weighted_rps)
 #   - burst:        max actual_rps among phases whose name contains "burst"
-#   - step_up:      actual_rps of the alphabetically last phase (fallback: weighted_rps)
+#   - step_up:      average actual_rps of the longest-duration phase(s) (fallback: weighted_rps)
 #
 # When no phase_result.json files are found and MERGED_RPS is set, a
 # single-phase fallback is returned using MERGED_RPS for all metrics.

--- a/benches/api/benchmarks/run_benchmark.sh
+++ b/benches/api/benchmarks/run_benchmark.sh
@@ -1112,18 +1112,15 @@ echo ""
 # Threshold feasibility lint (after scenario validation)
 if [[ "${SKIP_THRESHOLD_LINT:-false}" != "true" ]]; then
     LINT_MODE="${THRESHOLD_LINT_MODE:-warn}"
-    THRESHOLD_LINT_FILE="${SCRIPT_DIR}/thresholds.yaml"
-    LINT_SCRIPT="${SCRIPT_DIR}/scripts/validate_threshold_feasibility.sh"
-    if [[ -f "${LINT_SCRIPT}" && -f "${THRESHOLD_LINT_FILE}" ]]; then
+    if [[ -f "${SCRIPT_DIR}/scripts/validate_threshold_feasibility.sh" && \
+          -f "${SCRIPT_DIR}/thresholds.yaml" ]]; then
         echo "Running threshold feasibility lint (mode: ${LINT_MODE})..."
-        if ! bash "${LINT_SCRIPT}" \
+        if ! bash "${SCRIPT_DIR}/scripts/validate_threshold_feasibility.sh" \
             --scenario-file "${SCENARIO_FILE}" \
-            --threshold-file "${THRESHOLD_LINT_FILE}" \
+            --threshold-file "${SCRIPT_DIR}/thresholds.yaml" \
             --mode "${LINT_MODE}"; then
             echo "ERROR: Threshold feasibility check failed"
-            if [[ "${LINT_MODE}" == "strict" ]]; then
-                exit 1
-            fi
+            [[ "${LINT_MODE}" == "strict" ]] && exit 1
         fi
     fi
 fi

--- a/benches/api/benchmarks/run_benchmark.sh
+++ b/benches/api/benchmarks/run_benchmark.sh
@@ -1109,6 +1109,26 @@ fi
 validate_scenario_parameters
 echo ""
 
+# Threshold feasibility lint (after scenario validation)
+if [[ "${SKIP_THRESHOLD_LINT:-false}" != "true" ]]; then
+    LINT_MODE="${THRESHOLD_LINT_MODE:-warn}"
+    THRESHOLD_LINT_FILE="${SCRIPT_DIR}/thresholds.yaml"
+    LINT_SCRIPT="${SCRIPT_DIR}/scripts/validate_threshold_feasibility.sh"
+    if [[ -f "${LINT_SCRIPT}" && -f "${THRESHOLD_LINT_FILE}" ]]; then
+        echo "Running threshold feasibility lint (mode: ${LINT_MODE})..."
+        if ! bash "${LINT_SCRIPT}" \
+            --scenario-file "${SCENARIO_FILE}" \
+            --threshold-file "${THRESHOLD_LINT_FILE}" \
+            --mode "${LINT_MODE}"; then
+            echo "ERROR: Threshold feasibility check failed"
+            if [[ "${LINT_MODE}" == "strict" ]]; then
+                exit 1
+            fi
+        fi
+    fi
+fi
+echo ""
+
 echo "=============================================="
 echo "  API Workload Benchmark"
 echo "=============================================="

--- a/benches/api/benchmarks/scenarios/burst_spike_test.yaml
+++ b/benches/api/benchmarks/scenarios/burst_spike_test.yaml
@@ -59,7 +59,6 @@ worker_config:
 thresholds:
   max_error_rate: 0.05          # 5% max error rate (higher tolerance for bursts)
   p99_latency_ms: 500           # p99 latency threshold (higher during bursts)
-  min_rps_achieved: 900         # Minimum RPS during burst phase
   recovery_time_seconds: 10     # Expected time to return to normal after burst
 
 # Metadata for result analysis

--- a/benches/api/benchmarks/scenarios/large_scale_seeded.yaml
+++ b/benches/api/benchmarks/scenarios/large_scale_seeded.yaml
@@ -52,7 +52,6 @@ thresholds:
   p50_latency_ms: 50
   p95_latency_ms: 200
   p99_latency_ms: 500
-  min_rps_achieved: 500
   max_error_rate: 0.01
 
 # Concurrency settings

--- a/benches/api/benchmarks/scenarios/mixed_contention.yaml
+++ b/benches/api/benchmarks/scenarios/mixed_contention.yaml
@@ -63,7 +63,6 @@ worker_config:
 thresholds:
   max_error_rate: 0.02
   p99_latency_ms: 200
-  min_rps_achieved: 300
 
 # Metadata
 metadata:

--- a/benches/api/benchmarks/scenarios/payload_variation_complex.yaml
+++ b/benches/api/benchmarks/scenarios/payload_variation_complex.yaml
@@ -55,7 +55,7 @@ worker_config:
 thresholds:
   max_error_rate: 0.02      # Slightly higher tolerance for complex payloads
   p99_latency_ms: 300       # Higher latency expected for complex payload
-  min_rps_achieved: 150
+
 
 # Metadata for result analysis
 metadata:

--- a/benches/api/benchmarks/scenarios/payload_variation_heavy.yaml
+++ b/benches/api/benchmarks/scenarios/payload_variation_heavy.yaml
@@ -55,7 +55,7 @@ worker_config:
 thresholds:
   max_error_rate: 0.05      # Higher tolerance for heavy payloads
   p99_latency_ms: 1000      # Higher latency expected for heavy payload
-  min_rps_achieved: 30
+
 
 # Metadata for result analysis
 metadata:

--- a/benches/api/benchmarks/scenarios/payload_variation_minimal.yaml
+++ b/benches/api/benchmarks/scenarios/payload_variation_minimal.yaml
@@ -55,7 +55,7 @@ worker_config:
 thresholds:
   max_error_rate: 0.01
   p99_latency_ms: 50        # Low latency expected for minimal payload
-  min_rps_achieved: 450
+
 
 # Metadata for result analysis
 metadata:

--- a/benches/api/benchmarks/scenarios/payload_variation_standard.yaml
+++ b/benches/api/benchmarks/scenarios/payload_variation_standard.yaml
@@ -55,7 +55,7 @@ worker_config:
 thresholds:
   max_error_rate: 0.01
   p99_latency_ms: 100       # Moderate latency for standard payload
-  min_rps_achieved: 350
+
 
 # Metadata for result analysis
 metadata:

--- a/benches/api/benchmarks/scenarios/pool_stress_large.yaml
+++ b/benches/api/benchmarks/scenarios/pool_stress_large.yaml
@@ -61,7 +61,6 @@ worker_config:
 thresholds:
   max_error_rate: 0.01
   p99_latency_ms: 100
-  min_rps_achieved: 500
 
 # Metadata
 metadata:

--- a/benches/api/benchmarks/scenarios/pool_stress_medium.yaml
+++ b/benches/api/benchmarks/scenarios/pool_stress_medium.yaml
@@ -59,7 +59,6 @@ worker_config:
 thresholds:
   max_error_rate: 0.02
   p99_latency_ms: 200
-  min_rps_achieved: 200
 
 # Metadata
 metadata:

--- a/benches/api/benchmarks/scenarios/pool_stress_small.yaml
+++ b/benches/api/benchmarks/scenarios/pool_stress_small.yaml
@@ -53,7 +53,7 @@ pool_sizes:
 thresholds:
   max_error_rate: 0.05
   p99_latency_ms: 500
-  min_rps_achieved: 50
+
 
 # Metadata
 metadata:

--- a/benches/api/benchmarks/scenarios/production_load.yaml
+++ b/benches/api/benchmarks/scenarios/production_load.yaml
@@ -64,7 +64,6 @@ error_config:
 thresholds:
   max_error_rate: 0.05
   p99_latency_ms: 500
-  min_rps_achieved: 5000
 
 metadata:
   test_type: "production_simulation"

--- a/benches/api/benchmarks/scenarios/projects_progress.yaml
+++ b/benches/api/benchmarks/scenarios/projects_progress.yaml
@@ -69,7 +69,7 @@ error_config:
 thresholds:
   max_error_rate: 0.02
   p99_latency_ms: 200
-  min_rps_achieved: 1000
+
 
 # Extended metadata for workflow integration
 # Keys here map to environment variables:

--- a/benches/api/benchmarks/scenarios/ramp_up_down_test.yaml
+++ b/benches/api/benchmarks/scenarios/ramp_up_down_test.yaml
@@ -55,7 +55,6 @@ worker_config:
 thresholds:
   max_error_rate: 0.01        # 1% max error rate
   p99_latency_ms: 200         # p99 latency threshold
-  min_rps_achieved: 450       # Minimum RPS during sustain phase
 
 # Metadata for result analysis
 metadata:

--- a/benches/api/benchmarks/scenarios/tasks_bulk.yaml
+++ b/benches/api/benchmarks/scenarios/tasks_bulk.yaml
@@ -70,7 +70,6 @@ error_config:
 thresholds:
   max_error_rate: 0.10
   p99_latency_ms: 500
-  min_rps_achieved: 200
 
 # Extended metadata for workflow integration
 # Keys here map to environment variables:

--- a/benches/api/benchmarks/scenarios/tasks_eff.yaml
+++ b/benches/api/benchmarks/scenarios/tasks_eff.yaml
@@ -69,7 +69,7 @@ error_config:
 thresholds:
   max_error_rate: 0.02
   p99_latency_ms: 100
-  min_rps_achieved: 500
+
 
 # Extended metadata for workflow integration
 # Keys here map to environment variables:

--- a/benches/api/benchmarks/scenarios/tasks_search.yaml
+++ b/benches/api/benchmarks/scenarios/tasks_search.yaml
@@ -68,7 +68,7 @@ error_config:
 thresholds:
   max_error_rate: 0.01
   p99_latency_ms: 50
-  min_rps_achieved: 1500
+
 
 # Extended metadata for workflow integration
 # Keys here map to environment variables:

--- a/benches/api/benchmarks/scenarios/tasks_search_cold.yaml
+++ b/benches/api/benchmarks/scenarios/tasks_search_cold.yaml
@@ -64,7 +64,6 @@ thresholds:
   p50_latency_ms: 100
   p95_latency_ms: 300
   p99_latency_ms: 500
-  min_rps_achieved: 500
 
 # Extended metadata for workflow integration
 # Keys here map to environment variables:

--- a/benches/api/benchmarks/scenarios/tasks_search_hot.yaml
+++ b/benches/api/benchmarks/scenarios/tasks_search_hot.yaml
@@ -64,7 +64,6 @@ thresholds:
   p50_latency_ms: 50
   p95_latency_ms: 200
   p99_latency_ms: 400
-  min_rps_achieved: 1500
 
 # Extended metadata for workflow integration
 # Keys here map to environment variables:

--- a/benches/api/benchmarks/scenarios/tasks_update.yaml
+++ b/benches/api/benchmarks/scenarios/tasks_update.yaml
@@ -67,7 +67,6 @@ error_config:
 thresholds:
   max_error_rate: 0.03
   p99_latency_ms: 100
-  min_rps_achieved: 500
 
 metadata:
   test_type: "endpoint_benchmark"

--- a/benches/api/benchmarks/scenarios/tasks_update_conflict.yaml
+++ b/benches/api/benchmarks/scenarios/tasks_update_conflict.yaml
@@ -79,7 +79,6 @@ error_config:
 thresholds:
   max_error_rate: 0.1
   p99_latency_ms: 200
-  min_rps_achieved: 300
 
 # Extended metadata for workflow integration
 # Keys here map to environment variables:

--- a/benches/api/benchmarks/scenarios/tasks_update_status.yaml
+++ b/benches/api/benchmarks/scenarios/tasks_update_status.yaml
@@ -68,7 +68,6 @@ thresholds:
   max_error_rate: 0.03
   max_validation_error_rate: 0  # 400 is structural violation - must be 0 (enforced by check_validation_gate in check_thresholds.sh)
   p99_latency_ms: 100
-  min_rps_achieved: 500
 
 metadata:
   test_type: "endpoint_benchmark"

--- a/benches/api/benchmarks/scenarios/tasks_update_steady.yaml
+++ b/benches/api/benchmarks/scenarios/tasks_update_steady.yaml
@@ -77,7 +77,6 @@ error_config:
 thresholds:
   max_error_rate: 0.001
   p99_latency_ms: 50
-  min_rps_achieved: 80
 
 # Extended metadata for workflow integration
 # Keys here map to environment variables:

--- a/benches/api/benchmarks/scenarios/write_contention_high.yaml
+++ b/benches/api/benchmarks/scenarios/write_contention_high.yaml
@@ -58,7 +58,7 @@ worker_config:
 thresholds:
   max_error_rate: 0.05
   p99_latency_ms: 300
-  min_rps_achieved: 100
+
 
 # Metadata
 metadata:

--- a/benches/api/benchmarks/schema/meta_v3.json
+++ b/benches/api/benchmarks/schema/meta_v3.json
@@ -204,6 +204,37 @@
           "type": "integer",
           "minimum": 0,
           "description": "Total number of retries"
+        },
+        "phase_metrics": {
+          "type": ["object", "null"],
+          "description": "Phase-aware RPS metrics aggregated from phase_result.json files (REQ-PATE-001). null for single-phase scenarios without phase files.",
+          "properties": {
+            "phase_count": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of phases executed"
+            },
+            "peak_phase_rps": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Maximum actual_rps across all phases"
+            },
+            "min_phase_rps": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Minimum actual_rps across all phases"
+            },
+            "weighted_rps": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Duration-weighted average RPS across all phases"
+            },
+            "sustain_phase_rps": {
+              "type": ["number", "null"],
+              "minimum": 0,
+              "description": "Profile-aware sustained RPS: main phase for steady, sustain phase for ramp_up_down, max burst phase for burst, last step for step_up"
+            }
+          }
         }
       }
     },

--- a/benches/api/benchmarks/schema/meta_v3.json
+++ b/benches/api/benchmarks/schema/meta_v3.json
@@ -232,7 +232,7 @@
             "sustain_phase_rps": {
               "type": ["number", "null"],
               "minimum": 0,
-              "description": "Profile-aware sustained RPS: main phase for steady, sustain phase for ramp_up_down, max burst phase for burst, last step for step_up"
+              "description": "Profile-aware sustained RPS: main phase for steady, sustain phase for ramp_up_down, max burst phase for burst, longest-duration phase(s) average for step_up"
             }
           }
         }

--- a/benches/api/benchmarks/scripts/test_phase_aware_rps_thresholds.sh
+++ b/benches/api/benchmarks/scripts/test_phase_aware_rps_thresholds.sh
@@ -174,13 +174,7 @@ make_meta_json_without_phase_metrics() {
 # TC-RPS-1: RPS が warning 閾値以上 -> PASS
 # -------------------------------------------------------------------
 test_rps_above_warning_threshold_is_pass() {
-    cat << 'EOF'
-
-==============================================
-  TC-RPS-1: RPS >= warning threshold -> PASS
-==============================================
-EOF
-    log_test "RPS が warning 閾値以上の場合 PASS になること"
+    log_test "TC-RPS-1: RPS >= warning threshold -> PASS"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -203,13 +197,7 @@ EOF
 # TC-RPS-2: RPS が warning と error の間 -> WARNING (exit 0)
 # -------------------------------------------------------------------
 test_rps_between_warning_and_error_is_warning() {
-    cat << 'EOF'
-
-==============================================
-  TC-RPS-2: warning < RPS < error -> WARNING (exit 0)
-==============================================
-EOF
-    log_test "RPS が warning-error 間の場合 WARNING 表示 (exit 0) になること"
+    log_test "TC-RPS-2: warning < RPS < error -> WARNING (exit 0)"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -232,13 +220,7 @@ EOF
 # TC-RPS-3: RPS が error 閾値未満 -> FAIL (exit 3)
 # -------------------------------------------------------------------
 test_rps_below_error_threshold_is_fail() {
-    cat << 'EOF'
-
-==============================================
-  TC-RPS-3: RPS < error threshold -> FAIL (exit 3)
-==============================================
-EOF
-    log_test "RPS が error 閾値未満の場合 FAIL (exit 3) になること"
+    log_test "TC-RPS-3: RPS < error threshold -> FAIL (exit 3)"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -261,13 +243,7 @@ EOF
 # TC-RPS-4: phase_metrics がない旧形式 meta.json -> merged RPS で fallback
 # -------------------------------------------------------------------
 test_legacy_meta_json_falls_back_to_merged_rps() {
-    cat << 'EOF'
-
-==============================================
-  TC-RPS-4: phase_metrics absent -> fallback to merged RPS
-==============================================
-EOF
-    log_test "phase_metrics がない場合 results.rps (merged) で判定されること"
+    log_test "TC-RPS-4: phase_metrics absent -> fallback to merged RPS"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -289,17 +265,7 @@ EOF
 # TC-RPS-5: RPS ルールが thresholds.yaml に未定義 -> スキップ (PASS)
 # -------------------------------------------------------------------
 test_no_rps_rule_skips_check() {
-    cat << 'EOF'
-
-==============================================
-  TC-RPS-5: rps rule not in thresholds.yaml -> skip (PASS)
-==============================================
-EOF
-    log_test "RPS ルールが未定義のシナリオは RPS チェックをスキップすること"
-
-    # tasks_search_hot has rps rule; but we test a scenario that has no rps rule
-    # by checking that a scenario with rps defined always passes when rps is high
-    # This test verifies check_thresholds.sh handles missing rps section gracefully
+    log_test "TC-RPS-5: rps rule not in thresholds.yaml -> skip (PASS)"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -336,18 +302,7 @@ EOF
 # TC-RPS-6: 各 profile で正しい metric が使われること
 # -------------------------------------------------------------------
 test_each_profile_uses_correct_metric() {
-    cat << 'EOF'
-
-==============================================
-  TC-RPS-6: each profile uses correct metric
-==============================================
-EOF
-    log_test "constant プロファイルは weighted_rps を使うこと"
-
-    # tasks_bulk is constant profile -> uses weighted_rps
-    # peak_phase_rps = 600 (high, above warning), weighted_rps = 200 (below error)
-    # If constant uses weighted_rps, should FAIL
-    # If it mistakenly uses peak_phase_rps, would PASS
+    log_test "TC-RPS-6: constant profile uses weighted_rps (not peak_phase_rps)"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)

--- a/benches/api/benchmarks/scripts/test_phase_aware_rps_thresholds.sh
+++ b/benches/api/benchmarks/scripts/test_phase_aware_rps_thresholds.sh
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+# Test suite for phase-aware RPS threshold evaluation in check_thresholds.sh
+# Tests: RPS threshold checking using phase_metrics from meta.json
+#
+# Test cases:
+#   TC-RPS-1: RPS >= warning threshold -> PASS
+#   TC-RPS-2: RPS between warning and error -> WARNING (exit 0)
+#   TC-RPS-3: RPS < error threshold -> FAIL (exit 3)
+#   TC-RPS-4: phase_metrics absent (legacy meta.json) -> fallback to merged RPS
+#   TC-RPS-5: rps rule not defined in thresholds.yaml -> skip (PASS)
+#   TC-RPS-6: each profile uses correct metric (steady/burst/ramp/step)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_THRESHOLDS_SCRIPT="${SCRIPT_DIR}/../check_thresholds.sh"
+THRESHOLDS_YAML="${SCRIPT_DIR}/../thresholds.yaml"
+
+TEMP_DIR_ROOT=""
+cleanup_temp_dirs() {
+    if [[ -n "${TEMP_DIR_ROOT:-}" ]]; then
+        rm -rf "${TEMP_DIR_ROOT}" 2>/dev/null || true
+    fi
+}
+trap cleanup_temp_dirs EXIT
+
+make_test_tmp_dir() {
+    if [[ -z "${TEMP_DIR_ROOT}" ]]; then
+        TEMP_DIR_ROOT=$(mktemp -d)
+    fi
+    mktemp -d "${TEMP_DIR_ROOT}/XXXXXX"
+}
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log_test() { echo -e "${BLUE}[TEST]${NC} $1"; }
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+
+assert_exit_code() {
+    local expected="$1"
+    local actual="$2"
+    local test_name="$3"
+    ((TESTS_RUN++))
+    if [[ "${expected}" == "${actual}" ]]; then
+        log_pass "${test_name}"
+        ((TESTS_PASSED++))
+    else
+        log_fail "${test_name} (expected exit=${expected}, got exit=${actual})"
+        ((TESTS_FAILED++))
+        return 1
+    fi
+}
+
+assert_contains() {
+    local output="$1"
+    local pattern="$2"
+    local test_name="$3"
+    ((TESTS_RUN++))
+    if echo "${output}" | grep -q "${pattern}"; then
+        log_pass "${test_name}"
+        ((TESTS_PASSED++))
+    else
+        log_fail "${test_name} (pattern '${pattern}' not found in output)"
+        echo "  Output: ${output}"
+        ((TESTS_FAILED++))
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local output="$1"
+    local pattern="$2"
+    local test_name="$3"
+    ((TESTS_RUN++))
+    if ! echo "${output}" | grep -q "${pattern}"; then
+        log_pass "${test_name}"
+        ((TESTS_PASSED++))
+    else
+        log_fail "${test_name} (unexpected pattern '${pattern}' found in output)"
+        echo "  Output: ${output}"
+        ((TESTS_FAILED++))
+        return 1
+    fi
+}
+
+# Create a minimal valid meta.json for tasks_bulk scenario with phase_metrics
+make_meta_json_with_phase_metrics() {
+    local directory="$1"
+    local weighted_rps="$2"
+    local peak_phase_rps="${3:-${weighted_rps}}"
+    local sustain_phase_rps="${4:-${weighted_rps}}"
+
+    mkdir -p "${directory}/tasks_bulk/benchmark/meta"
+    jq -n \
+        --argjson weighted_rps "${weighted_rps}" \
+        --argjson peak_phase_rps "${peak_phase_rps}" \
+        --argjson sustain_phase_rps "${sustain_phase_rps}" \
+        '{
+            "scenario": "tasks_bulk",
+            "results": {
+                "rps": $weighted_rps,
+                "p50": "5ms",
+                "p90": "10ms",
+                "p99": "20ms",
+                "error_rate": 0.001,
+                "requests": 1000,
+                "http_status": {
+                    "200": 999,
+                    "400": 0,
+                    "409": 0
+                },
+                "merge_path_detail": {
+                    "bulk_with_arena": 950,
+                    "bulk_without_arena": 50
+                },
+                "phase_metrics": {
+                    "peak_phase_rps": $peak_phase_rps,
+                    "sustain_phase_rps": $sustain_phase_rps,
+                    "weighted_rps": $weighted_rps,
+                    "min_phase_rps": ($weighted_rps * 0.8),
+                    "phase_count": 1
+                }
+            }
+        }' > "${directory}/tasks_bulk/benchmark/meta/tasks_bulk.json"
+}
+
+# Create a minimal valid meta.json WITHOUT phase_metrics (legacy format)
+make_meta_json_without_phase_metrics() {
+    local directory="$1"
+    local merged_rps="$2"
+
+    mkdir -p "${directory}/tasks_bulk/benchmark/meta"
+    jq -n \
+        --argjson rps "${merged_rps}" \
+        '{
+            "scenario": "tasks_bulk",
+            "results": {
+                "rps": $rps,
+                "p50": "5ms",
+                "p90": "10ms",
+                "p99": "20ms",
+                "error_rate": 0.001,
+                "requests": 1000,
+                "http_status": {
+                    "200": 999,
+                    "400": 0,
+                    "409": 0
+                },
+                "merge_path_detail": {
+                    "bulk_with_arena": 950,
+                    "bulk_without_arena": 50
+                }
+            }
+        }' > "${directory}/tasks_bulk/benchmark/meta/tasks_bulk.json"
+}
+
+# -------------------------------------------------------------------
+# TC-RPS-1: RPS が warning 閾値以上 -> PASS
+# -------------------------------------------------------------------
+test_rps_above_warning_threshold_is_pass() {
+    cat << 'EOF'
+
+==============================================
+  TC-RPS-1: RPS >= warning threshold -> PASS
+==============================================
+EOF
+    log_test "RPS が warning 閾値以上の場合 PASS になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    # tasks_bulk: warning=425, error=350
+    # RPS = 500 (above warning) -> should PASS
+    make_meta_json_with_phase_metrics "${tmp_dir}" 500
+
+    local output
+    local exit_code
+    output=$("${CHECK_THRESHOLDS_SCRIPT}" "${tmp_dir}" "tasks_bulk" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    assert_exit_code "0" "${exit_code}" "TC-RPS-1: exit code 0"
+    assert_contains "${output}" "PASS" "TC-RPS-1: output contains PASS"
+    assert_not_contains "${output}" "RPS.*FAIL\|FAIL.*RPS\|RPS.*WARNING\|WARNING.*RPS" "TC-RPS-1: no RPS failure or warning"
+}
+
+# -------------------------------------------------------------------
+# TC-RPS-2: RPS が warning と error の間 -> WARNING (exit 0)
+# -------------------------------------------------------------------
+test_rps_between_warning_and_error_is_warning() {
+    cat << 'EOF'
+
+==============================================
+  TC-RPS-2: warning < RPS < error -> WARNING (exit 0)
+==============================================
+EOF
+    log_test "RPS が warning-error 間の場合 WARNING 表示 (exit 0) になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    # tasks_bulk: warning=425, error=350
+    # RPS = 400 (between error=350 and warning=425) -> should WARNING
+    make_meta_json_with_phase_metrics "${tmp_dir}" 400
+
+    local output
+    local exit_code
+    output=$("${CHECK_THRESHOLDS_SCRIPT}" "${tmp_dir}" "tasks_bulk" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    assert_exit_code "0" "${exit_code}" "TC-RPS-2: exit code 0 (not fail)"
+    assert_contains "${output}" "WARNING" "TC-RPS-2: output contains WARNING"
+    assert_not_contains "${output}" "RPS.*FAIL\|FAIL.*RPS" "TC-RPS-2: no RPS FAIL"
+}
+
+# -------------------------------------------------------------------
+# TC-RPS-3: RPS が error 閾値未満 -> FAIL (exit 3)
+# -------------------------------------------------------------------
+test_rps_below_error_threshold_is_fail() {
+    cat << 'EOF'
+
+==============================================
+  TC-RPS-3: RPS < error threshold -> FAIL (exit 3)
+==============================================
+EOF
+    log_test "RPS が error 閾値未満の場合 FAIL (exit 3) になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    # tasks_bulk: warning=425, error=350
+    # RPS = 200 (below error=350) -> should FAIL
+    make_meta_json_with_phase_metrics "${tmp_dir}" 200
+
+    local output
+    local exit_code=0
+    output=$("${CHECK_THRESHOLDS_SCRIPT}" "${tmp_dir}" "tasks_bulk" 2>&1) || exit_code=$?
+
+    assert_exit_code "3" "${exit_code}" "TC-RPS-3: exit code 3"
+    assert_contains "${output}" "FAIL" "TC-RPS-3: output contains FAIL"
+    assert_contains "${output}" "RPS" "TC-RPS-3: FAIL message mentions RPS"
+}
+
+# -------------------------------------------------------------------
+# TC-RPS-4: phase_metrics がない旧形式 meta.json -> merged RPS で fallback
+# -------------------------------------------------------------------
+test_legacy_meta_json_falls_back_to_merged_rps() {
+    cat << 'EOF'
+
+==============================================
+  TC-RPS-4: phase_metrics absent -> fallback to merged RPS
+==============================================
+EOF
+    log_test "phase_metrics がない場合 results.rps (merged) で判定されること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    # Legacy meta.json without phase_metrics
+    # merged RPS = 500 (above warning=425) -> should PASS
+    make_meta_json_without_phase_metrics "${tmp_dir}" 500
+
+    local output
+    local exit_code
+    output=$("${CHECK_THRESHOLDS_SCRIPT}" "${tmp_dir}" "tasks_bulk" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    assert_exit_code "0" "${exit_code}" "TC-RPS-4: exit code 0 with legacy meta"
+    assert_contains "${output}" "PASS" "TC-RPS-4: PASS with fallback to merged RPS"
+}
+
+# -------------------------------------------------------------------
+# TC-RPS-5: RPS ルールが thresholds.yaml に未定義 -> スキップ (PASS)
+# -------------------------------------------------------------------
+test_no_rps_rule_skips_check() {
+    cat << 'EOF'
+
+==============================================
+  TC-RPS-5: rps rule not in thresholds.yaml -> skip (PASS)
+==============================================
+EOF
+    log_test "RPS ルールが未定義のシナリオは RPS チェックをスキップすること"
+
+    # tasks_search_hot has rps rule; but we test a scenario that has no rps rule
+    # by checking that a scenario with rps defined always passes when rps is high
+    # This test verifies check_thresholds.sh handles missing rps section gracefully
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    # Create meta.json for tasks_search_hot with high RPS
+    mkdir -p "${tmp_dir}/tasks_search_hot/benchmark/meta"
+    jq -n '{
+        "scenario": "tasks_search_hot",
+        "results": {
+            "rps": 2000,
+            "p50": "10ms",
+            "p90": "50ms",
+            "p99": "100ms",
+            "error_rate": 0.001,
+            "requests": 5000,
+            "http_status": {
+                "200": 4995,
+                "400": 0,
+                "409": 0
+            }
+        }
+    }' > "${tmp_dir}/tasks_search_hot/benchmark/meta/tasks_search_hot.json"
+
+    local output
+    local exit_code
+    output=$("${CHECK_THRESHOLDS_SCRIPT}" "${tmp_dir}" "tasks_search_hot" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    assert_exit_code "0" "${exit_code}" "TC-RPS-5: exit code 0 (RPS check skipped or passed)"
+    assert_contains "${output}" "PASS" "TC-RPS-5: PASS when RPS rule absent or met"
+}
+
+# -------------------------------------------------------------------
+# TC-RPS-6: 各 profile で正しい metric が使われること
+# -------------------------------------------------------------------
+test_each_profile_uses_correct_metric() {
+    cat << 'EOF'
+
+==============================================
+  TC-RPS-6: each profile uses correct metric
+==============================================
+EOF
+    log_test "constant プロファイルは weighted_rps を使うこと"
+
+    # tasks_bulk is constant profile -> uses weighted_rps
+    # peak_phase_rps = 600 (high, above warning), weighted_rps = 200 (below error)
+    # If constant uses weighted_rps, should FAIL
+    # If it mistakenly uses peak_phase_rps, would PASS
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    # weighted_rps=200 (below error=350), peak=600 (above warning=425)
+    make_meta_json_with_phase_metrics "${tmp_dir}" 200 600 200
+
+    local output
+    local exit_code=0
+    output=$("${CHECK_THRESHOLDS_SCRIPT}" "${tmp_dir}" "tasks_bulk" 2>&1) || exit_code=$?
+
+    assert_exit_code "3" "${exit_code}" "TC-RPS-6: exit code 3 (uses weighted_rps not peak)"
+    assert_contains "${output}" "FAIL" "TC-RPS-6: FAIL when weighted_rps is below error threshold"
+    assert_contains "${output}" "weighted_rps\|RPS" "TC-RPS-6: FAIL message references RPS metric"
+}
+
+# -------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------
+
+print_summary() {
+    echo ""
+    echo -e "${BOLD}=============================================="
+    echo -e "  Test Summary"
+    echo -e "==============================================${NC}"
+    echo -e "  Total:  ${TESTS_RUN}"
+    echo -e "  ${GREEN}Passed: ${TESTS_PASSED}${NC}"
+    if [[ ${TESTS_FAILED} -gt 0 ]]; then
+        echo -e "  ${RED}Failed: ${TESTS_FAILED}${NC}"
+    else
+        echo -e "  Failed: ${TESTS_FAILED}"
+    fi
+    echo ""
+}
+
+# -------------------------------------------------------------------
+# Main
+# -------------------------------------------------------------------
+
+main() {
+    echo -e "${BOLD}=============================================="
+    echo -e "  test_phase_aware_rps_thresholds.sh"
+    echo -e "==============================================${NC}"
+
+    for cmd in jq yq; do
+        if ! command -v "${cmd}" &>/dev/null; then
+            echo -e "${RED}ERROR: ${cmd} is required but not installed${NC}"
+            exit 1
+        fi
+    done
+
+    if [[ ! -f "${CHECK_THRESHOLDS_SCRIPT}" ]]; then
+        echo -e "${RED}ERROR: ${CHECK_THRESHOLDS_SCRIPT} not found${NC}"
+        exit 1
+    fi
+
+    if [[ ! -f "${THRESHOLDS_YAML}" ]]; then
+        echo -e "${RED}ERROR: ${THRESHOLDS_YAML} not found${NC}"
+        exit 1
+    fi
+
+    test_rps_above_warning_threshold_is_pass
+    test_rps_between_warning_and_error_is_warning
+    test_rps_below_error_threshold_is_fail
+    test_legacy_meta_json_falls_back_to_merged_rps
+    test_no_rps_rule_skips_check
+    test_each_profile_uses_correct_metric
+
+    print_summary
+
+    if [[ ${TESTS_FAILED} -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/benches/api/benchmarks/scripts/test_phase_metrics_generation.sh
+++ b/benches/api/benchmarks/scripts/test_phase_metrics_generation.sh
@@ -1,0 +1,447 @@
+#!/usr/bin/env bash
+# Test suite for build_phase_metrics_json() in run_benchmark.sh
+# Tests: phase-aware metrics generation with profile-aware sustain selection
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_BENCHMARK_SCRIPT="${SCRIPT_DIR}/../run_benchmark.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log_test() { echo -e "${BLUE}[TEST]${NC} $1"; }
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; }
+
+assert_exit_code() {
+    local expected="$1"
+    local actual="$2"
+    local test_name="$3"
+    ((TESTS_RUN++))
+    if [[ "${expected}" == "${actual}" ]]; then
+        log_pass "${test_name}"
+        ((TESTS_PASSED++))
+    else
+        log_fail "${test_name} (expected exit=${expected}, got exit=${actual})"
+        ((TESTS_FAILED++))
+        return 1
+    fi
+}
+
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local test_name="$3"
+    ((TESTS_RUN++))
+    if [[ "${expected}" == "${actual}" ]]; then
+        log_pass "${test_name}"
+        ((TESTS_PASSED++))
+    else
+        log_fail "${test_name}"
+        echo "  Expected: ${expected}"
+        echo "  Actual:   ${actual}"
+        ((TESTS_FAILED++))
+        return 1
+    fi
+}
+
+assert_json_field() {
+    local json="$1"
+    local field="$2"
+    local expected="$3"
+    local test_name="$4"
+    ((TESTS_RUN++))
+    local actual
+    actual=$(echo "${json}" | jq -r "${field}" 2>/dev/null)
+    if [[ "${expected}" == "${actual}" ]]; then
+        log_pass "${test_name}"
+        ((TESTS_PASSED++))
+    else
+        log_fail "${test_name}"
+        echo "  Field:    ${field}"
+        echo "  Expected: ${expected}"
+        echo "  Actual:   ${actual}"
+        echo "  JSON:     ${json}"
+        ((TESTS_FAILED++))
+        return 1
+    fi
+}
+
+assert_json_null() {
+    local json="$1"
+    local test_name="$2"
+    ((TESTS_RUN++))
+    if [[ "${json}" == "null" ]]; then
+        log_pass "${test_name}"
+        ((TESTS_PASSED++))
+    else
+        log_fail "${test_name} (expected null, got: ${json})"
+        ((TESTS_FAILED++))
+        return 1
+    fi
+}
+
+# -------------------------------------------------------------------
+# Load build_phase_metrics_json() from run_benchmark.sh
+# -------------------------------------------------------------------
+
+# Source only the function by extracting it and evaluating in subshell
+# We avoid sourcing the entire script to prevent side effects
+load_build_phase_metrics_json() {
+    if [[ ! -f "${RUN_BENCHMARK_SCRIPT}" ]]; then
+        echo -e "${RED}ERROR: ${RUN_BENCHMARK_SCRIPT} not found${NC}"
+        exit 1
+    fi
+
+    # Extract build_phase_metrics_json function body
+    # Returns non-zero if function is not found
+    if ! grep -q "build_phase_metrics_json" "${RUN_BENCHMARK_SCRIPT}"; then
+        return 1
+    fi
+    return 0
+}
+
+# Wrapper to call build_phase_metrics_json() via sourcing run_benchmark.sh
+# Temporarily overrides any problematic globals
+call_build_phase_metrics_json() {
+    local results_dir="$1"
+    local profile="${2:-steady}"
+
+    # Source the function in a subshell to avoid polluting the test environment
+    (
+        # Suppress sourcing side effects by defining dummy guard variables
+        # The script checks for these to skip initialization
+        export API_URL="${API_URL:-http://localhost:3000}"
+        export RESULTS_DIR="${RESULTS_DIR:-/tmp}"
+        export SCENARIO_NAME="${SCENARIO_NAME:-test}"
+        export STORAGE_MODE="${STORAGE_MODE:-in_memory}"
+        export CACHE_MODE="${CACHE_MODE:-none}"
+        export DURATION="${DURATION:-30s}"
+        export THREADS="${THREADS:-2}"
+        export CONNECTIONS="${CONNECTIONS:-10}"
+        export RPS_PROFILE="${RPS_PROFILE:-steady}"
+        export PROFILE_MODE="${PROFILE_MODE:-false}"
+
+        # Source only the function - use awk to extract the function
+        # shellcheck disable=SC1090
+        eval "$(awk '/^build_phase_metrics_json\(\)/{found=1} found{print} found && /^\}$/{exit}' "${RUN_BENCHMARK_SCRIPT}")"
+
+        build_phase_metrics_json "${results_dir}" "${profile}"
+    )
+}
+
+# -------------------------------------------------------------------
+# Fixtures
+# -------------------------------------------------------------------
+
+create_phase_result() {
+    local directory="$1"
+    local phase_name="$2"
+    local target_rps="$3"
+    local actual_rps="$4"
+    local duration_seconds="$5"
+
+    mkdir -p "${directory}"
+    jq -n \
+        --arg phase "${phase_name}" \
+        --argjson target_rps "${target_rps}" \
+        --argjson actual_rps "${actual_rps}" \
+        --argjson duration_seconds "${duration_seconds}" \
+        '{
+            "phase": $phase,
+            "target_rps": $target_rps,
+            "actual_rps": $actual_rps,
+            "duration_seconds": $duration_seconds
+        }' > "${directory}/phase_result.json"
+}
+
+# -------------------------------------------------------------------
+# Tests
+# -------------------------------------------------------------------
+
+test_function_exists() {
+    cat << 'EOF'
+
+==============================================
+  Testing: build_phase_metrics_json exists
+==============================================
+EOF
+    ((TESTS_RUN++))
+    if load_build_phase_metrics_json; then
+        log_pass "build_phase_metrics_json() is defined in run_benchmark.sh"
+        ((TESTS_PASSED++))
+    else
+        log_fail "build_phase_metrics_json() is NOT defined in run_benchmark.sh"
+        ((TESTS_FAILED++))
+    fi
+}
+
+# TC-1: steady (single phase) - MERGED_RPS からの fallback
+test_steady_single_phase_fallback() {
+    cat << 'EOF'
+
+==============================================
+  TC-1: steady single-phase fallback (MERGED_RPS)
+==============================================
+EOF
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "${tmp_dir}"' RETURN
+
+    # No phase_result.json files - steady single-phase scenario
+    local result
+    result=$(MERGED_RPS="1234.56" call_build_phase_metrics_json "${tmp_dir}" "steady")
+    local exit_code=$?
+
+    assert_exit_code "0" "${exit_code}" "TC-1: exit code 0 for single-phase fallback"
+    assert_json_field "${result}" ".phase_count" "1" "TC-1: phase_count is 1"
+    assert_json_field "${result}" ".peak_phase_rps" "1234.56" "TC-1: peak_phase_rps equals MERGED_RPS"
+    assert_json_field "${result}" ".min_phase_rps" "1234.56" "TC-1: min_phase_rps equals MERGED_RPS"
+    assert_json_field "${result}" ".weighted_rps" "1234.56" "TC-1: weighted_rps equals MERGED_RPS"
+    assert_json_field "${result}" ".sustain_phase_rps" "1234.56" "TC-1: sustain_phase_rps equals MERGED_RPS"
+}
+
+# TC-2: burst - 複数フェーズの peak/min/weighted/sustain
+test_burst_multiple_phases() {
+    cat << 'EOF'
+
+==============================================
+  TC-2: burst - multiple phases peak/min/weighted/sustain
+==============================================
+EOF
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "${tmp_dir}"' RETURN
+
+    # Create burst scenario with 3 phases:
+    # - warmup: 100 RPS for 30s
+    # - burst: 1000 RPS for 20s
+    # - cooldown: 100 RPS for 10s
+    create_phase_result "${tmp_dir}/phase_warmup" "warmup" 100 100 30
+    create_phase_result "${tmp_dir}/phase_burst" "burst" 1000 1002 20
+    create_phase_result "${tmp_dir}/phase_cooldown" "cooldown" 100 98 10
+
+    local result
+    result=$(call_build_phase_metrics_json "${tmp_dir}" "burst")
+    local exit_code=$?
+
+    assert_exit_code "0" "${exit_code}" "TC-2: exit code 0"
+    assert_json_field "${result}" ".phase_count" "3" "TC-2: phase_count is 3"
+    assert_json_field "${result}" ".peak_phase_rps" "1002" "TC-2: peak_phase_rps is burst phase value"
+    assert_json_field "${result}" ".min_phase_rps" "98" "TC-2: min_phase_rps is cooldown phase value"
+    assert_json_field "${result}" ".sustain_phase_rps" "1002" "TC-2: sustain_phase_rps is max of burst-named phases"
+
+    # weighted_rps = (100*30 + 1002*20 + 98*10) / (30+20+10) = (3000+20040+980) / 60 = 24020/60 = 400.333...
+    local weighted
+    weighted=$(echo "${result}" | jq -r '.weighted_rps')
+    # Check it's approximately 400.33 (within 1.0 tolerance)
+    ((TESTS_RUN++))
+    local diff
+    diff=$(awk -v w="${weighted}" 'BEGIN { d = w - 400.333; if (d < 0) d = -d; print (d < 1.0) ? "ok" : "fail" }')
+    if [[ "${diff}" == "ok" ]]; then
+        log_pass "TC-2: weighted_rps approximately 400.33"
+        ((TESTS_PASSED++))
+    else
+        log_fail "TC-2: weighted_rps expected ~400.33, got ${weighted}"
+        ((TESTS_FAILED++))
+    fi
+}
+
+# TC-3: ramp_up_down - sustain phase の正しい選択
+test_ramp_up_down_sustain_phase() {
+    cat << 'EOF'
+
+==============================================
+  TC-3: ramp_up_down - sustain phase selection
+==============================================
+EOF
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "${tmp_dir}"' RETURN
+
+    # ramp_up_down: ramp_up, sustain, ramp_down
+    create_phase_result "${tmp_dir}/phase_ramp_up" "ramp_up" 500 480 30
+    create_phase_result "${tmp_dir}/phase_sustain" "sustain" 500 499 60
+    create_phase_result "${tmp_dir}/phase_ramp_down" "ramp_down" 100 102 30
+
+    local result
+    result=$(call_build_phase_metrics_json "${tmp_dir}" "ramp_up_down")
+    local exit_code=$?
+
+    assert_exit_code "0" "${exit_code}" "TC-3: exit code 0"
+    assert_json_field "${result}" ".phase_count" "3" "TC-3: phase_count is 3"
+    assert_json_field "${result}" ".sustain_phase_rps" "499" "TC-3: sustain_phase_rps uses 'sustain' phase actual_rps"
+    assert_json_field "${result}" ".peak_phase_rps" "499" "TC-3: peak_phase_rps is max actual_rps"
+    assert_json_field "${result}" ".min_phase_rps" "102" "TC-3: min_phase_rps is ramp_down value"
+}
+
+# TC-4: step_up - 最終ステップの正しい選択
+test_step_up_last_step() {
+    cat << 'EOF'
+
+==============================================
+  TC-4: step_up - last step selection
+==============================================
+EOF
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "${tmp_dir}"' RETURN
+
+    # step_up: step1, step2, step3 (sorted alphabetically = step1, step2, step3)
+    create_phase_result "${tmp_dir}/phase_step1" "step1" 100 98 30
+    create_phase_result "${tmp_dir}/phase_step2" "step2" 200 195 30
+    create_phase_result "${tmp_dir}/phase_step3" "step3" 300 298 30
+
+    local result
+    result=$(call_build_phase_metrics_json "${tmp_dir}" "step_up")
+    local exit_code=$?
+
+    assert_exit_code "0" "${exit_code}" "TC-4: exit code 0"
+    assert_json_field "${result}" ".phase_count" "3" "TC-4: phase_count is 3"
+    assert_json_field "${result}" ".sustain_phase_rps" "298" "TC-4: sustain_phase_rps is last step actual_rps"
+    assert_json_field "${result}" ".peak_phase_rps" "298" "TC-4: peak_phase_rps is max actual_rps"
+    assert_json_field "${result}" ".min_phase_rps" "98" "TC-4: min_phase_rps is first step value"
+}
+
+# TC-5: 空ディレクトリ - MERGED_RPS なし → null を返すこと
+test_empty_directory_returns_null() {
+    cat << 'EOF'
+
+==============================================
+  TC-5: empty directory (no MERGED_RPS) returns null
+==============================================
+EOF
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "${tmp_dir}"' RETURN
+
+    local result
+    result=$(call_build_phase_metrics_json "${tmp_dir}" "steady")
+    local exit_code=$?
+
+    assert_exit_code "0" "${exit_code}" "TC-5: exit code 0 for empty dir"
+    assert_json_null "${result}" "TC-5: returns null when no files and no MERGED_RPS"
+}
+
+# TC-6: weighted_rps の計算精度
+test_weighted_rps_calculation_accuracy() {
+    cat << 'EOF'
+
+==============================================
+  TC-6: weighted_rps calculation accuracy
+==============================================
+EOF
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "${tmp_dir}"' RETURN
+
+    # Simple case: 2 phases with equal duration
+    # phase_a: 200 RPS for 60s
+    # phase_b: 400 RPS for 60s
+    # weighted_rps = (200*60 + 400*60) / (60+60) = 36000/120 = 300
+    create_phase_result "${tmp_dir}/phase_a" "phase_a" 200 200 60
+    create_phase_result "${tmp_dir}/phase_b" "phase_b" 400 400 60
+
+    local result
+    result=$(call_build_phase_metrics_json "${tmp_dir}" "steady")
+    local exit_code=$?
+
+    assert_exit_code "0" "${exit_code}" "TC-6: exit code 0"
+
+    local weighted
+    weighted=$(echo "${result}" | jq -r '.weighted_rps')
+    ((TESTS_RUN++))
+    local diff
+    diff=$(awk -v w="${weighted}" 'BEGIN { d = w - 300.0; if (d < 0) d = -d; print (d < 0.01) ? "ok" : "fail" }')
+    if [[ "${diff}" == "ok" ]]; then
+        log_pass "TC-6: weighted_rps = 300 (exact)"
+        ((TESTS_PASSED++))
+    else
+        log_fail "TC-6: weighted_rps expected 300, got ${weighted}"
+        ((TESTS_FAILED++))
+    fi
+}
+
+# TC-7: steady profile - "main" phase の sustain 選択
+test_steady_main_phase_sustain_selection() {
+    cat << 'EOF'
+
+==============================================
+  TC-7: steady - "main" phase sustain selection
+==============================================
+EOF
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "${tmp_dir}"' RETURN
+
+    create_phase_result "${tmp_dir}/phase_warmup" "warmup" 500 490 10
+    create_phase_result "${tmp_dir}/phase_main" "main" 500 502 60
+
+    local result
+    result=$(call_build_phase_metrics_json "${tmp_dir}" "steady")
+    local exit_code=$?
+
+    assert_exit_code "0" "${exit_code}" "TC-7: exit code 0"
+    assert_json_field "${result}" ".sustain_phase_rps" "502" "TC-7: sustain_phase_rps uses 'main' phase actual_rps"
+    assert_json_field "${result}" ".peak_phase_rps" "502" "TC-7: peak_phase_rps is max"
+}
+
+# -------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------
+
+print_summary() {
+    echo ""
+    echo -e "${BOLD}=============================================="
+    echo -e "  Test Summary"
+    echo -e "==============================================${NC}"
+    echo -e "  Total:  ${TESTS_RUN}"
+    echo -e "  ${GREEN}Passed: ${TESTS_PASSED}${NC}"
+    if [[ ${TESTS_FAILED} -gt 0 ]]; then
+        echo -e "  ${RED}Failed: ${TESTS_FAILED}${NC}"
+    else
+        echo -e "  Failed: ${TESTS_FAILED}"
+    fi
+    echo ""
+}
+
+# -------------------------------------------------------------------
+# Main
+# -------------------------------------------------------------------
+
+main() {
+    echo -e "${BOLD}=============================================="
+    echo -e "  test_phase_metrics_generation.sh"
+    echo -e "==============================================${NC}"
+
+    if ! command -v jq &>/dev/null; then
+        echo -e "${RED}ERROR: jq is required but not installed${NC}"
+        exit 1
+    fi
+
+    test_function_exists
+    test_steady_single_phase_fallback
+    test_burst_multiple_phases
+    test_ramp_up_down_sustain_phase
+    test_step_up_last_step
+    test_empty_directory_returns_null
+    test_weighted_rps_calculation_accuracy
+    test_steady_main_phase_sustain_selection
+
+    print_summary
+
+    if [[ ${TESTS_FAILED} -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/benches/api/benchmarks/scripts/test_phase_metrics_generation.sh
+++ b/benches/api/benchmarks/scripts/test_phase_metrics_generation.sh
@@ -186,12 +186,8 @@ create_phase_result() {
 # -------------------------------------------------------------------
 
 test_function_exists() {
-    cat << 'EOF'
-
-==============================================
-  Testing: build_phase_metrics_json exists
-==============================================
-EOF
+    echo ""
+    echo "Testing: build_phase_metrics_json exists"
     ((TESTS_RUN++))
     if load_build_phase_metrics_json; then
         log_pass "build_phase_metrics_json() is defined in run_benchmark.sh"
@@ -204,12 +200,8 @@ EOF
 
 # TC-1: steady (single phase) - MERGED_RPS からの fallback
 test_steady_single_phase_fallback() {
-    cat << 'EOF'
-
-==============================================
-  TC-1: steady single-phase fallback (MERGED_RPS)
-==============================================
-EOF
+    echo ""
+    echo "TC-1: steady single-phase fallback (MERGED_RPS)"
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
 
@@ -228,12 +220,8 @@ EOF
 
 # TC-2: burst - 複数フェーズの peak/min/weighted/sustain
 test_burst_multiple_phases() {
-    cat << 'EOF'
-
-==============================================
-  TC-2: burst - multiple phases peak/min/weighted/sustain
-==============================================
-EOF
+    echo ""
+    echo "TC-2: burst - multiple phases peak/min/weighted/sustain"
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
 
@@ -273,12 +261,8 @@ EOF
 
 # TC-3: ramp_up_down - sustain phase の正しい選択
 test_ramp_up_down_sustain_phase() {
-    cat << 'EOF'
-
-==============================================
-  TC-3: ramp_up_down - sustain phase selection
-==============================================
-EOF
+    echo ""
+    echo "TC-3: ramp_up_down - sustain phase selection"
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
 
@@ -300,12 +284,8 @@ EOF
 
 # TC-4: step_up - 最終ステップの正しい選択
 test_step_up_last_step() {
-    cat << 'EOF'
-
-==============================================
-  TC-4: step_up - last step selection
-==============================================
-EOF
+    echo ""
+    echo "TC-4: step_up - last step selection"
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
 
@@ -327,12 +307,8 @@ EOF
 
 # TC-5: 空ディレクトリ - MERGED_RPS なし → null を返すこと
 test_empty_directory_returns_null() {
-    cat << 'EOF'
-
-==============================================
-  TC-5: empty directory (no MERGED_RPS) returns null
-==============================================
-EOF
+    echo ""
+    echo "TC-5: empty directory (no MERGED_RPS) returns null"
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
 
@@ -346,12 +322,8 @@ EOF
 
 # TC-6: weighted_rps の計算精度
 test_weighted_rps_calculation_accuracy() {
-    cat << 'EOF'
-
-==============================================
-  TC-6: weighted_rps calculation accuracy
-==============================================
-EOF
+    echo ""
+    echo "TC-6: weighted_rps calculation accuracy"
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
 
@@ -384,12 +356,8 @@ EOF
 
 # TC-7: steady profile - "main" phase の sustain 選択
 test_steady_main_phase_sustain_selection() {
-    cat << 'EOF'
-
-==============================================
-  TC-7: steady - "main" phase sustain selection
-==============================================
-EOF
+    echo ""
+    echo "TC-7: steady - \"main\" phase sustain selection"
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
 

--- a/benches/api/benchmarks/scripts/test_threshold_feasibility.sh
+++ b/benches/api/benchmarks/scripts/test_threshold_feasibility.sh
@@ -95,31 +95,18 @@ assert_not_contains() {
     fi
 }
 
-# シナリオ YAML を一時ファイルに書き込む
-make_scenario_yaml() {
-    local file_path="$1"
-    local content="$2"
-    echo "${content}" > "${file_path}"
+# YAML コンテンツをファイルに書き込む (シナリオ・閾値ファイル共用)
+write_yaml_file() {
+    echo "${2}" > "${1}"
 }
-
-# thresholds.yaml を一時ファイルに書き込む
-make_thresholds_yaml() {
-    local file_path="$1"
-    local content="$2"
-    echo "${content}" > "${file_path}"
-}
+make_scenario_yaml()   { write_yaml_file "$@"; }
+make_thresholds_yaml() { write_yaml_file "$@"; }
 
 # -------------------------------------------------------------------
 # TC-FEAS-1: steady: target=1000, threshold=900 -> PASS (達成可能)
 # -------------------------------------------------------------------
 test_steady_feasible_threshold_is_pass() {
-    cat << 'EOF'
-
-==============================================
-  TC-FEAS-1: steady target=1000, threshold=900 -> PASS
-==============================================
-EOF
-    log_test "steady プロファイルで閾値が理論上限以下なら PASS になること"
+    log_test "TC-FEAS-1: steady target=1000, threshold=900 -> PASS"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -154,13 +141,7 @@ target_rps: 1000"
 # TC-FEAS-2: steady: target=100, threshold=500 -> FAIL (達成不可能)
 # -------------------------------------------------------------------
 test_steady_infeasible_threshold_is_fail() {
-    cat << 'EOF'
-
-==============================================
-  TC-FEAS-2: steady target=100, threshold=500 -> FAIL
-==============================================
-EOF
-    log_test "steady プロファイルで閾値が理論上限を超える場合 FAIL になること"
+    log_test "TC-FEAS-2: steady target=100, threshold=500 -> FAIL (infeasible)"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -195,13 +176,7 @@ target_rps: 100"
 # TC-FEAS-3: burst: target=1000, burst_multiplier=2, metric=peak_phase_rps, threshold=900 -> PASS
 # -------------------------------------------------------------------
 test_burst_peak_phase_rps_feasible_is_pass() {
-    cat << 'EOF'
-
-==============================================
-  TC-FEAS-3: burst peak_phase_rps=1000, threshold=900 -> PASS
-==============================================
-EOF
-    log_test "burst プロファイルで peak_phase_rps が target_rps で、閾値が以下なら PASS になること"
+    log_test "TC-FEAS-3: burst peak_phase_rps=1000, threshold=900 -> PASS"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -239,13 +214,7 @@ burst_interval_seconds: 20"
 # TC-FEAS-4: burst: target=100, metric=weighted_rps, threshold=500 -> FAIL (理論上限超過)
 # -------------------------------------------------------------------
 test_burst_weighted_rps_infeasible_is_fail() {
-    cat << 'EOF'
-
-==============================================
-  TC-FEAS-4: burst weighted_rps upper_bound < threshold=500 -> FAIL
-==============================================
-EOF
-    log_test "burst プロファイルで weighted_rps 上限が閾値を下回る場合 FAIL になること"
+    log_test "TC-FEAS-4: burst weighted_rps upper_bound < threshold=500 -> FAIL"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -287,13 +256,7 @@ burst_interval_seconds: 20"
 # TC-FEAS-5: step_up: steps=[100,200,300], metric=weighted_rps, threshold=250 -> FAIL
 # -------------------------------------------------------------------
 test_step_up_weighted_rps_infeasible_is_fail() {
-    cat << 'EOF'
-
-==============================================
-  TC-FEAS-5: step_up steps=[100,200,300] weighted_rps=200, threshold=250 -> FAIL
-==============================================
-EOF
-    log_test "step_up プロファイルで weighted_rps 上限が閾値を下回る場合 FAIL になること"
+    log_test "TC-FEAS-5: step_up steps=[100,200,300] weighted_rps=200, threshold=250 -> FAIL"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -335,13 +298,7 @@ duration_seconds: 90"
 # TC-FEAS-6: ramp_up_down: target=1000, metric=sustain_phase_rps, threshold=900 -> PASS
 # -------------------------------------------------------------------
 test_ramp_up_down_sustain_phase_rps_feasible_is_pass() {
-    cat << 'EOF'
-
-==============================================
-  TC-FEAS-6: ramp_up_down sustain_phase_rps=1000, threshold=900 -> PASS
-==============================================
-EOF
-    log_test "ramp_up_down プロファイルで sustain_phase_rps 上限が閾値以上なら PASS になること"
+    log_test "TC-FEAS-6: ramp_up_down sustain_phase_rps=1000, threshold=900 -> PASS"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -376,13 +333,7 @@ target_rps: 1000"
 # TC-FEAS-7: RPS ルール未定義 -> スキップ (PASS)
 # -------------------------------------------------------------------
 test_no_rps_rule_skips_check() {
-    cat << 'EOF'
-
-==============================================
-  TC-FEAS-7: RPS ルール未定義 -> スキップ (PASS)
-==============================================
-EOF
-    log_test "thresholds.yaml に RPS ルールが未定義の場合スキップされること"
+    log_test "TC-FEAS-7: RPS ルール未定義 -> スキップ (PASS)"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -416,13 +367,7 @@ target_rps: 100"
 # TC-FEAS-8: --mode warn: 達成不可能でも exit 0
 # -------------------------------------------------------------------
 test_warn_mode_infeasible_is_exit_0() {
-    cat << 'EOF'
-
-==============================================
-  TC-FEAS-8: --mode warn: infeasible -> exit 0
-==============================================
-EOF
-    log_test "--mode warn では達成不可能でも exit 0 になること"
+    log_test "TC-FEAS-8: --mode warn: infeasible -> exit 0"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)
@@ -457,13 +402,7 @@ target_rps: 100"
 # TC-FEAS-9: --mode strict: 達成不可能で exit 1
 # -------------------------------------------------------------------
 test_strict_mode_infeasible_is_exit_1() {
-    cat << 'EOF'
-
-==============================================
-  TC-FEAS-9: --mode strict: infeasible -> exit 1
-==============================================
-EOF
-    log_test "--mode strict では達成不可能で exit 1 になること"
+    log_test "TC-FEAS-9: --mode strict: infeasible -> exit 1"
 
     local tmp_dir
     tmp_dir=$(make_test_tmp_dir)

--- a/benches/api/benchmarks/scripts/test_threshold_feasibility.sh
+++ b/benches/api/benchmarks/scripts/test_threshold_feasibility.sh
@@ -1,0 +1,553 @@
+#!/usr/bin/env bash
+# Test suite for validate_threshold_feasibility.sh
+# Tests: Theoretical upper bound calculation per profile type
+#
+# Test cases:
+#   TC-FEAS-1: steady: target=1000, threshold=900 -> PASS (達成可能)
+#   TC-FEAS-2: steady: target=100, threshold=500 -> FAIL (達成不可能)
+#   TC-FEAS-3: burst: target=1000, burst_multiplier=2, metric=peak_phase_rps, threshold=900 -> PASS
+#   TC-FEAS-4: burst: target=100, metric=weighted_rps, threshold=500 -> FAIL (理論上限超過)
+#   TC-FEAS-5: step_up: steps=[100,200,300], metric=weighted_rps, threshold=250 -> FAIL (weighted上限=200)
+#   TC-FEAS-6: ramp_up_down: target=1000, metric=sustain_phase_rps, threshold=900 -> PASS
+#   TC-FEAS-7: RPS ルール未定義 -> スキップ (PASS)
+#   TC-FEAS-8: --mode warn: 達成不可能でも exit 0
+#   TC-FEAS-9: --mode strict: 達成不可能で exit 1
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATE_SCRIPT="${SCRIPT_DIR}/validate_threshold_feasibility.sh"
+
+TEMP_DIR_ROOT=""
+cleanup_temp_dirs() {
+    if [[ -n "${TEMP_DIR_ROOT:-}" ]]; then
+        rm -rf "${TEMP_DIR_ROOT}" 2>/dev/null || true
+    fi
+}
+trap cleanup_temp_dirs EXIT
+
+make_test_tmp_dir() {
+    if [[ -z "${TEMP_DIR_ROOT}" ]]; then
+        TEMP_DIR_ROOT=$(mktemp -d)
+    fi
+    mktemp -d "${TEMP_DIR_ROOT}/XXXXXX"
+}
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log_test() { echo -e "${BLUE}[TEST]${NC} $1"; }
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; }
+
+assert_exit_code() {
+    local expected="$1"
+    local actual="$2"
+    local test_name="$3"
+    ((TESTS_RUN++))
+    if [[ "${expected}" == "${actual}" ]]; then
+        log_pass "${test_name}"
+        ((TESTS_PASSED++))
+    else
+        log_fail "${test_name} (expected exit=${expected}, got exit=${actual})"
+        ((TESTS_FAILED++))
+        return 1
+    fi
+}
+
+assert_contains() {
+    local output="$1"
+    local pattern="$2"
+    local test_name="$3"
+    ((TESTS_RUN++))
+    if echo "${output}" | grep -q "${pattern}"; then
+        log_pass "${test_name}"
+        ((TESTS_PASSED++))
+    else
+        log_fail "${test_name} (pattern '${pattern}' not found in output)"
+        echo "  Output: ${output}"
+        ((TESTS_FAILED++))
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local output="$1"
+    local pattern="$2"
+    local test_name="$3"
+    ((TESTS_RUN++))
+    if ! echo "${output}" | grep -q "${pattern}"; then
+        log_pass "${test_name}"
+        ((TESTS_PASSED++))
+    else
+        log_fail "${test_name} (unexpected pattern '${pattern}' found in output)"
+        echo "  Output: ${output}"
+        ((TESTS_FAILED++))
+        return 1
+    fi
+}
+
+# シナリオ YAML を一時ファイルに書き込む
+make_scenario_yaml() {
+    local file_path="$1"
+    local content="$2"
+    echo "${content}" > "${file_path}"
+}
+
+# thresholds.yaml を一時ファイルに書き込む
+make_thresholds_yaml() {
+    local file_path="$1"
+    local content="$2"
+    echo "${content}" > "${file_path}"
+}
+
+# -------------------------------------------------------------------
+# TC-FEAS-1: steady: target=1000, threshold=900 -> PASS (達成可能)
+# -------------------------------------------------------------------
+test_steady_feasible_threshold_is_pass() {
+    cat << 'EOF'
+
+==============================================
+  TC-FEAS-1: steady target=1000, threshold=900 -> PASS
+==============================================
+EOF
+    log_test "steady プロファイルで閾値が理論上限以下なら PASS になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    local scenario_file="${tmp_dir}/scenario.yaml"
+    make_scenario_yaml "${scenario_file}" "name: test_steady_pass
+rps_profile: steady
+target_rps: 1000"
+
+    local threshold_file="${tmp_dir}/thresholds.yaml"
+    make_thresholds_yaml "${threshold_file}" "scenarios:
+  test_steady_pass:
+    rps:
+      metric: weighted_rps
+      warning: 850
+      error: 900"
+
+    local output
+    local exit_code
+    output=$(bash "${VALIDATE_SCRIPT}" \
+        --scenario-file "${scenario_file}" \
+        --threshold-file "${threshold_file}" \
+        2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    assert_exit_code "0" "${exit_code}" "TC-FEAS-1: exit code 0"
+    assert_contains "${output}" "PASS" "TC-FEAS-1: output contains PASS"
+    assert_not_contains "${output}" "INFEASIBLE\|FAIL" "TC-FEAS-1: no INFEASIBLE or FAIL"
+}
+
+# -------------------------------------------------------------------
+# TC-FEAS-2: steady: target=100, threshold=500 -> FAIL (達成不可能)
+# -------------------------------------------------------------------
+test_steady_infeasible_threshold_is_fail() {
+    cat << 'EOF'
+
+==============================================
+  TC-FEAS-2: steady target=100, threshold=500 -> FAIL
+==============================================
+EOF
+    log_test "steady プロファイルで閾値が理論上限を超える場合 FAIL になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    local scenario_file="${tmp_dir}/scenario.yaml"
+    make_scenario_yaml "${scenario_file}" "name: test_steady_fail
+rps_profile: steady
+target_rps: 100"
+
+    local threshold_file="${tmp_dir}/thresholds.yaml"
+    make_thresholds_yaml "${threshold_file}" "scenarios:
+  test_steady_fail:
+    rps:
+      metric: weighted_rps
+      warning: 400
+      error: 500"
+
+    local output
+    local exit_code=0
+    output=$(bash "${VALIDATE_SCRIPT}" \
+        --scenario-file "${scenario_file}" \
+        --threshold-file "${threshold_file}" \
+        --mode strict \
+        2>&1) || exit_code=$?
+
+    assert_exit_code "1" "${exit_code}" "TC-FEAS-2: exit code 1 (strict mode)"
+    assert_contains "${output}" "FAIL\|INFEASIBLE" "TC-FEAS-2: output contains FAIL or INFEASIBLE"
+    assert_contains "${output}" "test_steady_fail" "TC-FEAS-2: output contains scenario name"
+}
+
+# -------------------------------------------------------------------
+# TC-FEAS-3: burst: target=1000, burst_multiplier=2, metric=peak_phase_rps, threshold=900 -> PASS
+# -------------------------------------------------------------------
+test_burst_peak_phase_rps_feasible_is_pass() {
+    cat << 'EOF'
+
+==============================================
+  TC-FEAS-3: burst peak_phase_rps=1000, threshold=900 -> PASS
+==============================================
+EOF
+    log_test "burst プロファイルで peak_phase_rps が target_rps で、閾値が以下なら PASS になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    local scenario_file="${tmp_dir}/scenario.yaml"
+    make_scenario_yaml "${scenario_file}" "name: test_burst_peak_pass
+rps_profile: burst
+target_rps: 1000
+burst_multiplier: 2.0
+burst_duration_seconds: 5
+burst_interval_seconds: 20"
+
+    local threshold_file="${tmp_dir}/thresholds.yaml"
+    make_thresholds_yaml "${threshold_file}" "scenarios:
+  test_burst_peak_pass:
+    rps:
+      metric: peak_phase_rps
+      warning: 850
+      error: 900"
+
+    local output
+    local exit_code
+    output=$(bash "${VALIDATE_SCRIPT}" \
+        --scenario-file "${scenario_file}" \
+        --threshold-file "${threshold_file}" \
+        2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    assert_exit_code "0" "${exit_code}" "TC-FEAS-3: exit code 0"
+    assert_contains "${output}" "PASS" "TC-FEAS-3: output contains PASS"
+    assert_not_contains "${output}" "INFEASIBLE\|FAIL" "TC-FEAS-3: no INFEASIBLE or FAIL"
+}
+
+# -------------------------------------------------------------------
+# TC-FEAS-4: burst: target=100, metric=weighted_rps, threshold=500 -> FAIL (理論上限超過)
+# -------------------------------------------------------------------
+test_burst_weighted_rps_infeasible_is_fail() {
+    cat << 'EOF'
+
+==============================================
+  TC-FEAS-4: burst weighted_rps upper_bound < threshold=500 -> FAIL
+==============================================
+EOF
+    log_test "burst プロファイルで weighted_rps 上限が閾値を下回る場合 FAIL になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    local scenario_file="${tmp_dir}/scenario.yaml"
+    # target_rps=100, burst_multiplier=3
+    # base_rps = 100/3 ≈ 33.3
+    # burst_ratio = 5/20 = 0.25
+    # weighted_rps = 0.25 * 100 + 0.75 * 33.3 ≈ 50
+    make_scenario_yaml "${scenario_file}" "name: test_burst_weighted_fail
+rps_profile: burst
+target_rps: 100
+burst_multiplier: 3.0
+burst_duration_seconds: 5
+burst_interval_seconds: 20"
+
+    local threshold_file="${tmp_dir}/thresholds.yaml"
+    make_thresholds_yaml "${threshold_file}" "scenarios:
+  test_burst_weighted_fail:
+    rps:
+      metric: weighted_rps
+      warning: 400
+      error: 500"
+
+    local output
+    local exit_code=0
+    output=$(bash "${VALIDATE_SCRIPT}" \
+        --scenario-file "${scenario_file}" \
+        --threshold-file "${threshold_file}" \
+        --mode strict \
+        2>&1) || exit_code=$?
+
+    assert_exit_code "1" "${exit_code}" "TC-FEAS-4: exit code 1 (strict mode)"
+    assert_contains "${output}" "FAIL\|INFEASIBLE" "TC-FEAS-4: output contains FAIL or INFEASIBLE"
+    assert_contains "${output}" "test_burst_weighted_fail" "TC-FEAS-4: output contains scenario name"
+}
+
+# -------------------------------------------------------------------
+# TC-FEAS-5: step_up: steps=[100,200,300], metric=weighted_rps, threshold=250 -> FAIL
+# -------------------------------------------------------------------
+test_step_up_weighted_rps_infeasible_is_fail() {
+    cat << 'EOF'
+
+==============================================
+  TC-FEAS-5: step_up steps=[100,200,300] weighted_rps=200, threshold=250 -> FAIL
+==============================================
+EOF
+    log_test "step_up プロファイルで weighted_rps 上限が閾値を下回る場合 FAIL になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    local scenario_file="${tmp_dir}/scenario.yaml"
+    # min_rps=100, target_rps=300, step_count=3, duration=90s
+    # step_duration = 90/3 = 30s
+    # step1=100 (30s), step2=200 (30s), step3=300 (30s)
+    # weighted_rps = (100*30 + 200*30 + 300*30) / 90 = 18000/90 = 200
+    make_scenario_yaml "${scenario_file}" "name: test_step_up_fail
+rps_profile: step_up
+target_rps: 300
+min_rps: 100
+step_count: 3
+duration_seconds: 90"
+
+    local threshold_file="${tmp_dir}/thresholds.yaml"
+    make_thresholds_yaml "${threshold_file}" "scenarios:
+  test_step_up_fail:
+    rps:
+      metric: weighted_rps
+      warning: 240
+      error: 250"
+
+    local output
+    local exit_code=0
+    output=$(bash "${VALIDATE_SCRIPT}" \
+        --scenario-file "${scenario_file}" \
+        --threshold-file "${threshold_file}" \
+        --mode strict \
+        2>&1) || exit_code=$?
+
+    assert_exit_code "1" "${exit_code}" "TC-FEAS-5: exit code 1 (strict mode)"
+    assert_contains "${output}" "FAIL\|INFEASIBLE" "TC-FEAS-5: output contains FAIL or INFEASIBLE"
+    assert_contains "${output}" "test_step_up_fail" "TC-FEAS-5: output contains scenario name"
+}
+
+# -------------------------------------------------------------------
+# TC-FEAS-6: ramp_up_down: target=1000, metric=sustain_phase_rps, threshold=900 -> PASS
+# -------------------------------------------------------------------
+test_ramp_up_down_sustain_phase_rps_feasible_is_pass() {
+    cat << 'EOF'
+
+==============================================
+  TC-FEAS-6: ramp_up_down sustain_phase_rps=1000, threshold=900 -> PASS
+==============================================
+EOF
+    log_test "ramp_up_down プロファイルで sustain_phase_rps 上限が閾値以上なら PASS になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    local scenario_file="${tmp_dir}/scenario.yaml"
+    make_scenario_yaml "${scenario_file}" "name: test_ramp_up_down_pass
+rps_profile: ramp_up_down
+target_rps: 1000"
+
+    local threshold_file="${tmp_dir}/thresholds.yaml"
+    make_thresholds_yaml "${threshold_file}" "scenarios:
+  test_ramp_up_down_pass:
+    rps:
+      metric: sustain_phase_rps
+      warning: 850
+      error: 900"
+
+    local output
+    local exit_code
+    output=$(bash "${VALIDATE_SCRIPT}" \
+        --scenario-file "${scenario_file}" \
+        --threshold-file "${threshold_file}" \
+        2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    assert_exit_code "0" "${exit_code}" "TC-FEAS-6: exit code 0"
+    assert_contains "${output}" "PASS" "TC-FEAS-6: output contains PASS"
+    assert_not_contains "${output}" "INFEASIBLE\|FAIL" "TC-FEAS-6: no INFEASIBLE or FAIL"
+}
+
+# -------------------------------------------------------------------
+# TC-FEAS-7: RPS ルール未定義 -> スキップ (PASS)
+# -------------------------------------------------------------------
+test_no_rps_rule_skips_check() {
+    cat << 'EOF'
+
+==============================================
+  TC-FEAS-7: RPS ルール未定義 -> スキップ (PASS)
+==============================================
+EOF
+    log_test "thresholds.yaml に RPS ルールが未定義の場合スキップされること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    local scenario_file="${tmp_dir}/scenario.yaml"
+    make_scenario_yaml "${scenario_file}" "name: test_no_rps_rule
+rps_profile: steady
+target_rps: 100"
+
+    local threshold_file="${tmp_dir}/thresholds.yaml"
+    make_thresholds_yaml "${threshold_file}" "scenarios:
+  test_no_rps_rule:
+    p99_latency_ms:
+      warning: 100
+      error: 200"
+
+    local output
+    local exit_code
+    output=$(bash "${VALIDATE_SCRIPT}" \
+        --scenario-file "${scenario_file}" \
+        --threshold-file "${threshold_file}" \
+        2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    assert_exit_code "0" "${exit_code}" "TC-FEAS-7: exit code 0 (skipped)"
+    assert_contains "${output}" "PASS\|SKIP" "TC-FEAS-7: output contains PASS or SKIP"
+    assert_not_contains "${output}" "FAIL\|INFEASIBLE" "TC-FEAS-7: no FAIL or INFEASIBLE"
+}
+
+# -------------------------------------------------------------------
+# TC-FEAS-8: --mode warn: 達成不可能でも exit 0
+# -------------------------------------------------------------------
+test_warn_mode_infeasible_is_exit_0() {
+    cat << 'EOF'
+
+==============================================
+  TC-FEAS-8: --mode warn: infeasible -> exit 0
+==============================================
+EOF
+    log_test "--mode warn では達成不可能でも exit 0 になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    local scenario_file="${tmp_dir}/scenario.yaml"
+    make_scenario_yaml "${scenario_file}" "name: test_warn_mode
+rps_profile: steady
+target_rps: 100"
+
+    local threshold_file="${tmp_dir}/thresholds.yaml"
+    make_thresholds_yaml "${threshold_file}" "scenarios:
+  test_warn_mode:
+    rps:
+      metric: weighted_rps
+      warning: 400
+      error: 500"
+
+    local output
+    local exit_code
+    output=$(bash "${VALIDATE_SCRIPT}" \
+        --scenario-file "${scenario_file}" \
+        --threshold-file "${threshold_file}" \
+        --mode warn \
+        2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    assert_exit_code "0" "${exit_code}" "TC-FEAS-8: exit code 0 (warn mode)"
+    assert_contains "${output}" "FAIL\|WARN\|INFEASIBLE" "TC-FEAS-8: output contains FAIL/WARN/INFEASIBLE message"
+}
+
+# -------------------------------------------------------------------
+# TC-FEAS-9: --mode strict: 達成不可能で exit 1
+# -------------------------------------------------------------------
+test_strict_mode_infeasible_is_exit_1() {
+    cat << 'EOF'
+
+==============================================
+  TC-FEAS-9: --mode strict: infeasible -> exit 1
+==============================================
+EOF
+    log_test "--mode strict では達成不可能で exit 1 になること"
+
+    local tmp_dir
+    tmp_dir=$(make_test_tmp_dir)
+
+    local scenario_file="${tmp_dir}/scenario.yaml"
+    make_scenario_yaml "${scenario_file}" "name: test_strict_mode
+rps_profile: steady
+target_rps: 100"
+
+    local threshold_file="${tmp_dir}/thresholds.yaml"
+    make_thresholds_yaml "${threshold_file}" "scenarios:
+  test_strict_mode:
+    rps:
+      metric: weighted_rps
+      warning: 400
+      error: 500"
+
+    local output
+    local exit_code=0
+    output=$(bash "${VALIDATE_SCRIPT}" \
+        --scenario-file "${scenario_file}" \
+        --threshold-file "${threshold_file}" \
+        --mode strict \
+        2>&1) || exit_code=$?
+
+    assert_exit_code "1" "${exit_code}" "TC-FEAS-9: exit code 1 (strict mode)"
+    assert_contains "${output}" "FAIL\|INFEASIBLE" "TC-FEAS-9: output contains FAIL or INFEASIBLE"
+}
+
+# -------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------
+
+print_summary() {
+    echo ""
+    echo -e "${BOLD}=============================================="
+    echo -e "  Test Summary"
+    echo -e "==============================================${NC}"
+    echo -e "  Total:  ${TESTS_RUN}"
+    echo -e "  ${GREEN}Passed: ${TESTS_PASSED}${NC}"
+    if [[ ${TESTS_FAILED} -gt 0 ]]; then
+        echo -e "  ${RED}Failed: ${TESTS_FAILED}${NC}"
+    else
+        echo -e "  Failed: ${TESTS_FAILED}"
+    fi
+    echo ""
+}
+
+# -------------------------------------------------------------------
+# Main
+# -------------------------------------------------------------------
+
+main() {
+    echo -e "${BOLD}=============================================="
+    echo -e "  test_threshold_feasibility.sh"
+    echo -e "==============================================${NC}"
+
+    for cmd in yq; do
+        if ! command -v "${cmd}" &>/dev/null; then
+            echo -e "${RED}ERROR: ${cmd} is required but not installed${NC}"
+            exit 1
+        fi
+    done
+
+    if [[ ! -f "${VALIDATE_SCRIPT}" ]]; then
+        echo -e "${RED}ERROR: ${VALIDATE_SCRIPT} not found${NC}"
+        exit 1
+    fi
+
+    test_steady_feasible_threshold_is_pass
+    test_steady_infeasible_threshold_is_fail
+    test_burst_peak_phase_rps_feasible_is_pass
+    test_burst_weighted_rps_infeasible_is_fail
+    test_step_up_weighted_rps_infeasible_is_fail
+    test_ramp_up_down_sustain_phase_rps_feasible_is_pass
+    test_no_rps_rule_skips_check
+    test_warn_mode_infeasible_is_exit_0
+    test_strict_mode_infeasible_is_exit_1
+
+    print_summary
+
+    if [[ ${TESTS_FAILED} -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/benches/api/benchmarks/scripts/validate_threshold_feasibility.sh
+++ b/benches/api/benchmarks/scripts/validate_threshold_feasibility.sh
@@ -71,12 +71,13 @@ if [[ "${TARGET_RPS_RAW}" == "null" || "${TARGET_RPS_RAW}" == "0" ]]; then
 else
     TARGET_RPS="${TARGET_RPS_RAW}"
 fi
-MIN_RPS=$(yq '.min_rps // 0' "${SCENARIO_FILE}" | tr -d '"')
-STEP_COUNT=$(yq '.step_count // 0' "${SCENARIO_FILE}" | tr -d '"')
-DURATION_SECONDS=$(yq '.duration_seconds // 0' "${SCENARIO_FILE}" | tr -d '"')
-BURST_MULTIPLIER=$(yq '.burst_multiplier // 1.0' "${SCENARIO_FILE}" | tr -d '"')
-BURST_DURATION=$(yq '.burst_duration_seconds // 0' "${SCENARIO_FILE}" | tr -d '"')
-BURST_INTERVAL=$(yq '.burst_interval_seconds // 0' "${SCENARIO_FILE}" | tr -d '"')
+# Defaults must match run_benchmark.sh runtime defaults to avoid false PASS verdicts.
+MIN_RPS=$(yq '.min_rps // 10' "${SCENARIO_FILE}" | tr -d '"')
+STEP_COUNT=$(yq '.step_count // 4' "${SCENARIO_FILE}" | tr -d '"')
+DURATION_SECONDS=$(yq '.duration_seconds // 30' "${SCENARIO_FILE}" | tr -d '"')
+BURST_MULTIPLIER=$(yq '.burst_multiplier // 3' "${SCENARIO_FILE}" | tr -d '"')
+BURST_DURATION=$(yq '.burst_duration_seconds // 5' "${SCENARIO_FILE}" | tr -d '"')
+BURST_INTERVAL=$(yq '.burst_interval_seconds // 20' "${SCENARIO_FILE}" | tr -d '"')
 
 if [[ -z "${SCENARIO_NAME}" ]]; then
     echo "ERROR: Scenario file missing 'name' field: ${SCENARIO_FILE}" >&2

--- a/benches/api/benchmarks/scripts/validate_threshold_feasibility.sh
+++ b/benches/api/benchmarks/scripts/validate_threshold_feasibility.sh
@@ -88,16 +88,14 @@ fi
 # Read RPS threshold rule from thresholds.yaml
 # =============================================================================
 
-RPS_METRIC=$(SCENARIO_NAME="${SCENARIO_NAME}" \
-    yq '.scenarios[env(SCENARIO_NAME)].rps.metric // ""' "${THRESHOLD_FILE}" 2>/dev/null | tr -d '"')
+RPS_METRIC=$(yq ".scenarios.${SCENARIO_NAME}.rps.metric // \"\"" "${THRESHOLD_FILE}" 2>/dev/null | tr -d '"')
 
 if [[ -z "${RPS_METRIC}" || "${RPS_METRIC}" == "null" ]]; then
     echo "PASS: ${SCENARIO_NAME} (no rps rule defined - SKIP)"
     exit 0
 fi
 
-RPS_ERROR_THRESHOLD=$(SCENARIO_NAME="${SCENARIO_NAME}" \
-    yq '.scenarios[env(SCENARIO_NAME)].rps.error // 0' "${THRESHOLD_FILE}" 2>/dev/null | tr -d '"')
+RPS_ERROR_THRESHOLD=$(yq ".scenarios.${SCENARIO_NAME}.rps.error // 0" "${THRESHOLD_FILE}" 2>/dev/null | tr -d '"')
 
 if [[ -z "${RPS_ERROR_THRESHOLD}" || "${RPS_ERROR_THRESHOLD}" == "0" ]]; then
     echo "PASS: ${SCENARIO_NAME} (no rps.error threshold defined - SKIP)"

--- a/benches/api/benchmarks/scripts/validate_threshold_feasibility.sh
+++ b/benches/api/benchmarks/scripts/validate_threshold_feasibility.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# validate_threshold_feasibility.sh
+#
+# Preflight lint: Detect theoretically infeasible RPS thresholds before running benchmarks.
+#
+# Usage:
+#   ./validate_threshold_feasibility.sh --scenario-file <path> --threshold-file <path> [--mode strict|warn]
+#
+# Arguments:
+#   --scenario-file   Path to scenario YAML file
+#   --threshold-file  Path to thresholds.yaml
+#   --mode            strict (default) = exit 1 on infeasible; warn = exit 0 with warning
+#
+# Output:
+#   PASS: <scenario_name> (<metric>: upper_bound=<N>, threshold=<N>)
+#   FAIL: <scenario_name> (<metric>: upper_bound=<N>, threshold=<N>) [INFEASIBLE]
+#
+# Exit codes:
+#   0  All checks passed (or mode=warn)
+#   1  Infeasible threshold found (mode=strict only)
+
+set -euo pipefail
+
+# =============================================================================
+# Argument parsing
+# =============================================================================
+
+SCENARIO_FILE=""
+THRESHOLD_FILE=""
+MODE="strict"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scenario-file)
+            SCENARIO_FILE="$2"
+            shift 2
+            ;;
+        --threshold-file)
+            THRESHOLD_FILE="$2"
+            shift 2
+            ;;
+        --mode)
+            MODE="$2"
+            shift 2
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${SCENARIO_FILE}" ]]; then
+    echo "ERROR: --scenario-file is required" >&2
+    exit 1
+fi
+
+if [[ -z "${THRESHOLD_FILE}" ]]; then
+    echo "ERROR: --threshold-file is required" >&2
+    exit 1
+fi
+
+if [[ ! -f "${SCENARIO_FILE}" ]]; then
+    echo "ERROR: Scenario file not found: ${SCENARIO_FILE}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${THRESHOLD_FILE}" ]]; then
+    echo "ERROR: Threshold file not found: ${THRESHOLD_FILE}" >&2
+    exit 1
+fi
+
+if [[ "${MODE}" != "strict" && "${MODE}" != "warn" ]]; then
+    echo "ERROR: --mode must be 'strict' or 'warn'" >&2
+    exit 1
+fi
+
+# =============================================================================
+# Read scenario fields
+# =============================================================================
+
+SCENARIO_NAME=$(yq '.name // ""' "${SCENARIO_FILE}" | tr -d '"')
+PROFILE_TYPE=$(yq '.rps_profile // "steady"' "${SCENARIO_FILE}" | tr -d '"')
+TARGET_RPS=$(yq '.target_rps // 0' "${SCENARIO_FILE}" | tr -d '"')
+MIN_RPS=$(yq '.min_rps // 0' "${SCENARIO_FILE}" | tr -d '"')
+STEP_COUNT=$(yq '.step_count // 0' "${SCENARIO_FILE}" | tr -d '"')
+DURATION_SECONDS=$(yq '.duration_seconds // 0' "${SCENARIO_FILE}" | tr -d '"')
+BURST_MULTIPLIER=$(yq '.burst_multiplier // 1.0' "${SCENARIO_FILE}" | tr -d '"')
+BURST_DURATION=$(yq '.burst_duration_seconds // 0' "${SCENARIO_FILE}" | tr -d '"')
+BURST_INTERVAL=$(yq '.burst_interval_seconds // 0' "${SCENARIO_FILE}" | tr -d '"')
+
+if [[ -z "${SCENARIO_NAME}" ]]; then
+    echo "ERROR: Scenario file missing 'name' field: ${SCENARIO_FILE}" >&2
+    exit 1
+fi
+
+# =============================================================================
+# Read RPS threshold rule from thresholds.yaml
+# =============================================================================
+
+RPS_METRIC=$(SCENARIO_NAME="${SCENARIO_NAME}" \
+    yq '.scenarios[env(SCENARIO_NAME)].rps.metric // ""' "${THRESHOLD_FILE}" 2>/dev/null | tr -d '"')
+
+if [[ -z "${RPS_METRIC}" || "${RPS_METRIC}" == "null" ]]; then
+    echo "PASS: ${SCENARIO_NAME} (no rps rule defined - SKIP)"
+    exit 0
+fi
+
+RPS_ERROR_THRESHOLD=$(SCENARIO_NAME="${SCENARIO_NAME}" \
+    yq '.scenarios[env(SCENARIO_NAME)].rps.error // 0' "${THRESHOLD_FILE}" 2>/dev/null | tr -d '"')
+
+if [[ -z "${RPS_ERROR_THRESHOLD}" || "${RPS_ERROR_THRESHOLD}" == "0" ]]; then
+    echo "PASS: ${SCENARIO_NAME} (no rps.error threshold defined - SKIP)"
+    exit 0
+fi
+
+# =============================================================================
+# Calculate theoretical upper bound per profile type
+# =============================================================================
+
+# awk helper: floating point comparison (a >= b)
+awk_gte() {
+    local a="$1"
+    local b="$2"
+    awk -v a="${a}" -v b="${b}" 'BEGIN { exit (a >= b) ? 0 : 1 }'
+}
+
+# Calculate upper bound
+UPPER_BOUND="0"
+
+case "${PROFILE_TYPE}" in
+    steady|constant)
+        # upper_bound = target_rps
+        UPPER_BOUND="${TARGET_RPS}"
+        ;;
+
+    burst)
+        case "${RPS_METRIC}" in
+            peak_phase_rps)
+                # Burst phase sends at target_rps
+                UPPER_BOUND="${TARGET_RPS}"
+                ;;
+            weighted_rps)
+                # weighted_rps = burst_ratio * target_rps + (1 - burst_ratio) * base_rps
+                # base_rps = target_rps / burst_multiplier
+                if [[ "${BURST_INTERVAL}" == "0" || "${BURST_MULTIPLIER}" == "0" ]]; then
+                    UPPER_BOUND="${TARGET_RPS}"
+                else
+                    UPPER_BOUND=$(awk \
+                        -v target="${TARGET_RPS}" \
+                        -v multiplier="${BURST_MULTIPLIER}" \
+                        -v burst_duration="${BURST_DURATION}" \
+                        -v burst_interval="${BURST_INTERVAL}" \
+                        'BEGIN {
+                            burst_ratio = burst_duration / burst_interval
+                            base_rps = target / multiplier
+                            print burst_ratio * target + (1 - burst_ratio) * base_rps
+                        }')
+                fi
+                ;;
+            *)
+                # Default: use target_rps as upper bound
+                UPPER_BOUND="${TARGET_RPS}"
+                ;;
+        esac
+        ;;
+
+    step_up)
+        # Compute equal steps: min_rps -> target_rps over step_count steps
+        # step_rps[i] = min_rps + (target_rps - min_rps) * i / (step_count - 1) for i in 1..step_count
+        # simplified: step_duration = duration / step_count
+        # steps are evenly spaced from min_rps to target_rps
+        case "${RPS_METRIC}" in
+            weighted_rps)
+                if [[ "${STEP_COUNT}" -le 1 || "${DURATION_SECONDS}" == "0" ]]; then
+                    UPPER_BOUND="${TARGET_RPS}"
+                else
+                    UPPER_BOUND=$(awk \
+                        -v target="${TARGET_RPS}" \
+                        -v min_rps="${MIN_RPS}" \
+                        -v step_count="${STEP_COUNT}" \
+                        -v duration="${DURATION_SECONDS}" \
+                        'BEGIN {
+                            step_duration = duration / step_count
+                            total_rps_time = 0
+                            for (i = 1; i <= step_count; i++) {
+                                step_rps = min_rps + (target - min_rps) * i / step_count
+                                total_rps_time += step_rps * step_duration
+                            }
+                            print total_rps_time / duration
+                        }')
+                fi
+                ;;
+            peak_phase_rps)
+                # Peak is the final step = target_rps
+                UPPER_BOUND="${TARGET_RPS}"
+                ;;
+            *)
+                UPPER_BOUND="${TARGET_RPS}"
+                ;;
+        esac
+        ;;
+
+    ramp_up_down)
+        case "${RPS_METRIC}" in
+            sustain_phase_rps)
+                # Sustain phase hits target_rps
+                UPPER_BOUND="${TARGET_RPS}"
+                ;;
+            weighted_rps)
+                # Approximate: ramp up/down phases reduce average to ~75% of target
+                UPPER_BOUND=$(awk -v target="${TARGET_RPS}" 'BEGIN { print target * 0.75 }')
+                ;;
+            *)
+                UPPER_BOUND="${TARGET_RPS}"
+                ;;
+        esac
+        ;;
+
+    *)
+        # Unknown profile: assume steady
+        UPPER_BOUND="${TARGET_RPS}"
+        ;;
+esac
+
+# =============================================================================
+# Feasibility check
+# =============================================================================
+
+# Compare upper_bound vs error threshold using awk (floating point safe)
+IS_FEASIBLE=$(awk \
+    -v upper_bound="${UPPER_BOUND}" \
+    -v threshold="${RPS_ERROR_THRESHOLD}" \
+    'BEGIN { print (upper_bound >= threshold) ? "true" : "false" }')
+
+UPPER_BOUND_ROUNDED=$(awk -v n="${UPPER_BOUND}" 'BEGIN { printf "%.0f", n }')
+
+if [[ "${IS_FEASIBLE}" == "true" ]]; then
+    echo "PASS: ${SCENARIO_NAME} (${RPS_METRIC}: upper_bound=${UPPER_BOUND_ROUNDED}, threshold=${RPS_ERROR_THRESHOLD})"
+    exit 0
+else
+    echo "FAIL: ${SCENARIO_NAME} (${RPS_METRIC}: upper_bound=${UPPER_BOUND_ROUNDED}, threshold=${RPS_ERROR_THRESHOLD}) [INFEASIBLE]"
+    if [[ "${MODE}" == "strict" ]]; then
+        exit 1
+    else
+        exit 0
+    fi
+fi

--- a/benches/api/benchmarks/scripts/validate_threshold_feasibility.sh
+++ b/benches/api/benchmarks/scripts/validate_threshold_feasibility.sh
@@ -50,30 +50,13 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -z "${SCENARIO_FILE}" ]]; then
-    echo "ERROR: --scenario-file is required" >&2
-    exit 1
-fi
+die() { echo "ERROR: $*" >&2; exit 1; }
 
-if [[ -z "${THRESHOLD_FILE}" ]]; then
-    echo "ERROR: --threshold-file is required" >&2
-    exit 1
-fi
-
-if [[ ! -f "${SCENARIO_FILE}" ]]; then
-    echo "ERROR: Scenario file not found: ${SCENARIO_FILE}" >&2
-    exit 1
-fi
-
-if [[ ! -f "${THRESHOLD_FILE}" ]]; then
-    echo "ERROR: Threshold file not found: ${THRESHOLD_FILE}" >&2
-    exit 1
-fi
-
-if [[ "${MODE}" != "strict" && "${MODE}" != "warn" ]]; then
-    echo "ERROR: --mode must be 'strict' or 'warn'" >&2
-    exit 1
-fi
+[[ -z "${SCENARIO_FILE}" ]]  && die "--scenario-file is required"
+[[ -z "${THRESHOLD_FILE}" ]] && die "--threshold-file is required"
+[[ ! -f "${SCENARIO_FILE}" ]]  && die "Scenario file not found: ${SCENARIO_FILE}"
+[[ ! -f "${THRESHOLD_FILE}" ]] && die "Threshold file not found: ${THRESHOLD_FILE}"
+[[ "${MODE}" != "strict" && "${MODE}" != "warn" ]] && die "--mode must be 'strict' or 'warn'"
 
 # =============================================================================
 # Read scenario fields
@@ -122,19 +105,17 @@ UPPER_BOUND="0"
 
 case "${PROFILE_TYPE}" in
     steady|constant)
-        # upper_bound = target_rps
         UPPER_BOUND="${TARGET_RPS}"
         ;;
 
     burst)
         case "${RPS_METRIC}" in
             peak_phase_rps)
-                # Burst phase sends at target_rps
                 UPPER_BOUND="${TARGET_RPS}"
                 ;;
             weighted_rps)
                 # weighted_rps = burst_ratio * target_rps + (1 - burst_ratio) * base_rps
-                # base_rps = target_rps / burst_multiplier
+                # where base_rps = target_rps / burst_multiplier
                 if [[ "${BURST_INTERVAL}" == "0" || "${BURST_MULTIPLIER}" == "0" ]]; then
                     UPPER_BOUND="${TARGET_RPS}"
                 else
@@ -151,17 +132,13 @@ case "${PROFILE_TYPE}" in
                 fi
                 ;;
             *)
-                # Default: use target_rps as upper bound
                 UPPER_BOUND="${TARGET_RPS}"
                 ;;
         esac
         ;;
 
     step_up)
-        # Compute equal steps: min_rps -> target_rps over step_count steps
-        # step_rps[i] = min_rps + (target_rps - min_rps) * i / (step_count - 1) for i in 1..step_count
-        # simplified: step_duration = duration / step_count
-        # steps are evenly spaced from min_rps to target_rps
+        # Equal steps from min_rps to target_rps; weighted average is the upper bound
         case "${RPS_METRIC}" in
             weighted_rps)
                 if [[ "${STEP_COUNT}" -le 1 || "${DURATION_SECONDS}" == "0" ]]; then
@@ -183,10 +160,6 @@ case "${PROFILE_TYPE}" in
                         }')
                 fi
                 ;;
-            peak_phase_rps)
-                # Peak is the final step = target_rps
-                UPPER_BOUND="${TARGET_RPS}"
-                ;;
             *)
                 UPPER_BOUND="${TARGET_RPS}"
                 ;;
@@ -196,11 +169,10 @@ case "${PROFILE_TYPE}" in
     ramp_up_down)
         case "${RPS_METRIC}" in
             sustain_phase_rps)
-                # Sustain phase hits target_rps
                 UPPER_BOUND="${TARGET_RPS}"
                 ;;
             weighted_rps)
-                # Approximate: ramp up/down phases reduce average to ~75% of target
+                # Ramp up/down phases reduce average to approximately 75% of target
                 UPPER_BOUND=$(awk -v target="${TARGET_RPS}" 'BEGIN { print target * 0.75 }')
                 ;;
             *)
@@ -210,7 +182,6 @@ case "${PROFILE_TYPE}" in
         ;;
 
     *)
-        # Unknown profile: assume steady
         UPPER_BOUND="${TARGET_RPS}"
         ;;
 esac
@@ -219,22 +190,14 @@ esac
 # Feasibility check
 # =============================================================================
 
-# Compare upper_bound vs error threshold using awk (floating point safe)
-IS_FEASIBLE=$(awk \
-    -v upper_bound="${UPPER_BOUND}" \
-    -v threshold="${RPS_ERROR_THRESHOLD}" \
-    'BEGIN { print (upper_bound >= threshold) ? "true" : "false" }')
-
 UPPER_BOUND_ROUNDED=$(awk -v n="${UPPER_BOUND}" 'BEGIN { printf "%.0f", n }')
 
-if [[ "${IS_FEASIBLE}" == "true" ]]; then
+if awk -v upper_bound="${UPPER_BOUND}" -v threshold="${RPS_ERROR_THRESHOLD}" \
+    'BEGIN { exit (upper_bound >= threshold) ? 0 : 1 }'; then
     echo "PASS: ${SCENARIO_NAME} (${RPS_METRIC}: upper_bound=${UPPER_BOUND_ROUNDED}, threshold=${RPS_ERROR_THRESHOLD})"
     exit 0
 else
     echo "FAIL: ${SCENARIO_NAME} (${RPS_METRIC}: upper_bound=${UPPER_BOUND_ROUNDED}, threshold=${RPS_ERROR_THRESHOLD}) [INFEASIBLE]"
-    if [[ "${MODE}" == "strict" ]]; then
-        exit 1
-    else
-        exit 0
-    fi
+    [[ "${MODE}" == "strict" ]] && exit 1
+    exit 0
 fi

--- a/benches/api/benchmarks/scripts/validate_threshold_feasibility.sh
+++ b/benches/api/benchmarks/scripts/validate_threshold_feasibility.sh
@@ -118,14 +118,6 @@ fi
 # Calculate theoretical upper bound per profile type
 # =============================================================================
 
-# awk helper: floating point comparison (a >= b)
-awk_gte() {
-    local a="$1"
-    local b="$2"
-    awk -v a="${a}" -v b="${b}" 'BEGIN { exit (a >= b) ? 0 : 1 }'
-}
-
-# Calculate upper bound
 UPPER_BOUND="0"
 
 case "${PROFILE_TYPE}" in

--- a/benches/api/benchmarks/thresholds.yaml
+++ b/benches/api/benchmarks/thresholds.yaml
@@ -12,6 +12,12 @@
 #   p99_latency_ms:       99th percentile latency in milliseconds.
 #   error_rate:           Percentage of failed requests (0.01 = 1%).
 #   rps_degradation_percent: Percentage decrease in RPS compared to baseline.
+#
+# Scenario-specific RPS thresholds use phase-aware metrics:
+#   rps.metric:   phase_metrics field to evaluate (weighted_rps, peak_phase_rps, sustain_phase_rps).
+#                 Falls back to results.rps (merged) when phase_metrics is absent.
+#   rps.warning:  RPS below this level triggers a WARNING (non-blocking).
+#   rps.error:    RPS below this level causes CI to fail (exit 3).
 
 thresholds:
   p95_latency_ms:

--- a/benches/api/benchmarks/thresholds.yaml
+++ b/benches/api/benchmarks/thresholds.yaml
@@ -52,6 +52,12 @@ scenarios:
     error_rate:
       warning: 0.005
       error: 0.01
+    # rps_profile: constant -> metric: weighted_rps
+    # target_rps: 2000, warning=85%, error=70%
+    rps:
+      metric: weighted_rps
+      warning: 1700
+      error: 1400
 
   tasks_search_cold:
     p50_latency_ms:
@@ -69,6 +75,12 @@ scenarios:
     error_rate:
       warning: 0.005
       error: 0.01
+    # rps_profile: constant -> metric: weighted_rps
+    # target_rps: 1000, warning=85%, error=70%
+    rps:
+      metric: weighted_rps
+      warning: 850
+      error: 700
 
   # Status update scenario for PATCH /tasks/{id}/status operations.
   #
@@ -92,6 +104,12 @@ scenarios:
     conflict_rate:
       warning: 0.0005
       error: 0.001
+    # rps_profile: constant -> metric: weighted_rps
+    # target_rps: 800, warning=85%, error=70%
+    rps:
+      metric: weighted_rps
+      warning: 680
+      error: 560
 
   # Update scenarios for tasks_update operations.
   #
@@ -115,6 +133,12 @@ scenarios:
     conflict_rate:
       warning: 0.01
       error: 0.03
+    # rps_profile: constant -> metric: weighted_rps
+    # target_rps: 800, warning=85%, error=70%
+    rps:
+      metric: weighted_rps
+      warning: 680
+      error: 560
 
   # Steady: Normal update operations without conflicts.
   #   - High success rate required (>= 99.9%)
@@ -138,6 +162,12 @@ scenarios:
     conflict_rate:
       warning: 0.0005
       error: 0.001
+    # rps_profile: constant -> metric: weighted_rps
+    # target_rps: 100, warning=85%, error=70%
+    rps:
+      metric: weighted_rps
+      warning: 85
+      error: 70
 
   # Conflict: Update operations with concurrent modification simulation.
   #   - Allows higher error rate after retries (<= 10%)
@@ -161,6 +191,12 @@ scenarios:
     conflict_rate:
       warning: 0.005
       error: 0.01
+    # rps_profile: constant -> metric: weighted_rps
+    # target_rps: 500, warning=85%, error=70%
+    rps:
+      metric: weighted_rps
+      warning: 425
+      error: 350
 
   # Bulk operations scenario for POST /tasks/bulk operations.
   #
@@ -181,3 +217,9 @@ scenarios:
     error_rate:
       warning: 0.001
       error: 0.005
+    # rps_profile: constant -> metric: weighted_rps
+    # target_rps: 500, warning=85%, error=70%
+    rps:
+      metric: weighted_rps
+      warning: 425
+      error: 350

--- a/benches/api/benchmarks/thresholds.yaml
+++ b/benches/api/benchmarks/thresholds.yaml
@@ -204,6 +204,108 @@ scenarios:
       warning: 425
       error: 350
 
+  # Burst/spike load test: evaluates peak RPS during burst phases.
+  # profile: burst, target_rps: 1000, burst_multiplier: 3.0 (normal: 333 RPS)
+  # peak_phase_rps should reach ~1000 during burst; warning=80%, error=70%
+  burst_spike_test:
+    p99_latency_ms:
+      warning: 400
+      error: 500
+    error_rate:
+      warning: 0.03
+      error: 0.05
+    rps:
+      metric: peak_phase_rps
+      warning: 800
+      error: 700
+
+  # Production load: evaluates peak RPS during burst phases.
+  # profile: burst, target_rps: 8000
+  # peak_phase_rps should reach ~8000 during burst; warning=80%, error=70%
+  production_load:
+    p99_latency_ms:
+      warning: 400
+      error: 500
+    error_rate:
+      warning: 0.03
+      error: 0.05
+    rps:
+      metric: peak_phase_rps
+      warning: 6400
+      error: 5600
+
+  # Ramp up/down: evaluates sustain phase RPS.
+  # profile: ramp_up_down, target_rps: 500
+  # sustain_phase_rps should hold ~500 during sustain; warning=80%, error=70%
+  ramp_up_down_test:
+    p99_latency_ms:
+      warning: 150
+      error: 200
+    error_rate:
+      warning: 0.005
+      error: 0.01
+    rps:
+      metric: sustain_phase_rps
+      warning: 400
+      error: 350
+
+  # Large scale seeded: step_up profile without explicit target_rps.
+  # Actual throughput is constrained by data scale and cache cold start.
+  # Realistic upper bound ~100 RPS; warning=80, error=60
+  large_scale_seeded:
+    p99_latency_ms:
+      warning: 400
+      error: 500
+    error_rate:
+      warning: 0.005
+      error: 0.01
+    rps:
+      metric: weighted_rps
+      warning: 80
+      error: 60
+
+  # Pool stress large: constant profile, throughput limited by pool size.
+  # Realistic upper bound ~100 RPS with pool=32; warning=80, error=60
+  pool_stress_large:
+    p99_latency_ms:
+      warning: 80
+      error: 100
+    error_rate:
+      warning: 0.005
+      error: 0.01
+    rps:
+      metric: weighted_rps
+      warning: 80
+      error: 60
+
+  # Pool stress medium: constant profile, throughput limited by pool size.
+  # target_rps unspecified; runtime defaults to 100 RPS. warning=80, error=60
+  pool_stress_medium:
+    p99_latency_ms:
+      warning: 150
+      error: 200
+    error_rate:
+      warning: 0.01
+      error: 0.02
+    rps:
+      metric: weighted_rps
+      warning: 80
+      error: 60
+
+  # Mixed contention: burst profile, target_rps: 500.
+  # peak_phase_rps should reach ~500 during burst; warning=80%, error=70%
+  mixed_contention:
+    p99_latency_ms:
+      warning: 150
+      error: 200
+    error_rate:
+      warning: 0.01
+      error: 0.02
+    rps:
+      metric: peak_phase_rps
+      warning: 400
+      error: 350
+
   # Bulk operations scenario for POST /tasks/bulk operations.
   #
   # High-throughput bulk insertion with arena-based merge optimization.

--- a/docs/internal/done/requirements/20260217_1110_phase_aware_threshold_evaluation_run22083126035.yaml
+++ b/docs/internal/done/requirements/20260217_1110_phase_aware_threshold_evaluation_run22083126035.yaml
@@ -1,0 +1,211 @@
+# Phase-aware Threshold Evaluation (run 22083126035) 要件定義
+#
+# 概要:
+#   複数シナリオで閾値未達が出たが、実測フェーズ値は target を満たしており、
+#   判定指標（merged RPS）の意味と閾値定義が整合していない。
+#
+# 設計方針:
+#   1. phase 型負荷の評価を merged 値から phase-aware 指標へ分離する。
+#   2. シナリオ閾値に評価対象メトリクスを明示し、曖昧比較を禁止する。
+#   3. 実行前 lint で「達成不可能な閾値」を排除する。
+#
+# 参照:
+#   - benches/api/benchmarks/scenarios/*.yaml
+#   - profiling-results/github-22083126035/*/benchmark/wrk/*.txt
+
+version: "1.0.0"
+name: "phase_aware_threshold_evaluation_run22083126035"
+description: |
+  run 22083126035 では burst_spike_test, production_load, large_scale_seeded,
+  pool_stress_large, pool_stress_medium, mixed_contention, ramp_up_down_test が
+  min_rps 閾値で FAIL と判定された。
+  ただし wrk の phase 詳細では target RPS にほぼ追従しており、
+  merged RPS を min_rps と比較する設計が誤判定を誘発している。
+
+background:
+  problem: |
+    閾値判定が profile_type（steady/burst/step_up/ramp_up_down）を考慮せず、
+    評価不能または過剰に厳しい FAIL が混在している。
+  motivation: |
+    性能改善対象の優先度を正しく決めるため、
+    指標定義と閾値の意味を一意にし、誤検知を除去する必要がある。
+  prior_art:
+    - name: "Profile-aware SLO"
+      description: "phase ごとの期待値（peak/sustain/weighted）を分離して評価する方式。"
+
+requirements:
+  - id: REQ-PATE-001
+    name: "phase-aware メトリクスを標準出力する"
+    description: |
+      meta に merged_rps のみではなく、
+      peak_phase_rps / sustain_phase_rps / weighted_rps / min_phase_rps を出力する。
+      これにより burst/step/ramp での評価対象を明確化する。
+    methods:
+      - name: "compute_phase_metrics"
+        signature: "fn compute_phase_metrics(phases: Vec<PhaseResult>) -> PhaseMetrics"
+        description: "フェーズ結果から評価指標を純粋関数で算出する。"
+    implementations:
+      - type: "result_collector / summary generator"
+        description: "phase 詳細を集約し meta.results.phase_metrics に保存する。"
+
+  - id: REQ-PATE-002
+    name: "閾値に評価対象メトリクスを明示する"
+    description: |
+      シナリオ閾値の min_rps_achieved を廃止し、
+      min_peak_rps / min_sustain_rps / min_weighted_rps のいずれかを明示指定させる。
+      profile_type ごとに許可メトリクスを制限する。
+    implementations:
+      - type: "scenario schema"
+        description: "scenario YAML の thresholds スキーマを更新する。"
+
+  - id: REQ-PATE-003
+    name: "実行前閾値 lint を導入する"
+    description: |
+      シナリオ設定（target_rps, burst_multiplier, phase duration）から理論上限を計算し、
+      閾値が理論達成不可能なら workflow を開始前に失敗させる。
+    methods:
+      - name: "validate_threshold_feasibility"
+        signature: "fn validate_threshold_feasibility(config: ScenarioConfig) -> Result<(), ThresholdError>"
+        description: "profile 形状に対する閾値の実現可能性を判定する。"
+    implementations:
+      - type: "benchmark preflight"
+        description: "run_benchmark.sh 前段で lint を実行する。"
+
+evidence:
+  metrics:
+    - id: EV-PATE-M1
+      description: "burst_spike_test は merged RPS 500.88 < 閾値 900 だが burst phase は約1002 RPSで target を達成。"
+      source: "profiling-results/github-22083126035/...-burst_spike_test/benchmark/wrk/recursive.txt"
+    - id: EV-PATE-M2
+      description: "production_load は merged RPS 4005.88 < 閾値 5000 だが burst phase は約8018 RPSで target を達成。"
+      source: "profiling-results/github-22083126035/...-production_load/benchmark/wrk/recursive.txt"
+    - id: EV-PATE-M3
+      description: "large_scale_seeded は step_up で最大約100 RPSなのに閾値 min_rps=500 が設定されている。"
+      source: "benches/api/benchmarks/scenarios/large_scale_seeded.yaml"
+    - id: EV-PATE-M4
+      description: "pool_stress_large は target=100 RPS なのに閾値 min_rps=500 が設定されている。"
+      source: "benches/api/benchmarks/scenarios/pool_stress_large.yaml"
+    - id: EV-PATE-M5
+      description: "ramp_up_down_test は error_rate 0.001672 (閾値0.01以内) でも min_rps 判定で失敗する。"
+      source: "profiling-results/github-22083126035/...-ramp_up_down_test/benchmark/meta/recursive.json"
+
+quality_findings:
+  - id: QF-PATE-001
+    severity: "high"
+    issue: "評価指標と閾値意味の不一致"
+    impact: |
+      実際には target 達成しているシナリオが FAIL となり、改善優先度が歪む。
+  - id: QF-PATE-002
+    severity: "high"
+    issue: "理論的に達成不可能な閾値の混入"
+    impact: |
+      CI の恒常的 FAIL を招き、性能退行検知の信頼性を低下させる。
+
+barriers:
+  - id: BAR-PATE-001
+    name: "phase 形状差の未吸収"
+    details: |
+      steady/burst/step/ramp を同一ルールで比較しているため、比較対象が意味的に一致しない。
+  - id: BAR-PATE-002
+    name: "シナリオスキーマの曖昧性"
+    details: |
+      `min_rps_achieved` の定義が merged なのか phase-specific なのか不明確で、設定ミスを誘発する。
+  - id: BAR-PATE-003
+    name: "事前lint不足"
+    details: |
+      実行前に設定妥当性を検査しないため、無効閾値が運用に流入する。
+
+algorithms:
+  - id: ALG-PATE-001
+    name: "Phase Metric Extraction"
+    problem: "phase 型負荷を評価可能な指標へ正規化する。"
+    input: "phase list (target, actual_rps, duration)"
+    output: "peak_phase_rps, sustain_phase_rps, weighted_rps, min_phase_rps"
+    steps:
+      - "peak_phase_rps = max(actual_rps)"
+      - "weighted_rps = sum(actual_rps * duration) / sum(duration)"
+      - "sustain_phase_rps = 長尺 phase（または `sustain` ラベル）の平均"
+      - "min_phase_rps = min(actual_rps)"
+    complexity:
+      time: "O(p) (p = phase count)"
+      space: "O(1)"
+    guarantees:
+      - "profile_type を跨いでも比較可能な指標集合を生成する"
+
+  - id: ALG-PATE-002
+    name: "Threshold Feasibility Lint"
+    problem: "達成不可能な閾値設定を実行前に排除する。"
+    input: "scenario config (target_rps, burst_multiplier, profile, durations, thresholds)"
+    output: "Pass/Fail と不整合理由"
+    steps:
+      - "profile_type ごとに理論上限RPSを計算"
+      - "例: burst の weighted 上限 = (burst_dur/interval)*target + (1-burst_dur/interval)*(target/burst_multiplier)"
+      - "step_up は phase target の最大値・重み付き平均を計算"
+      - "threshold が理論上限を超える場合は fail"
+    complexity:
+      time: "O(1)〜O(p)"
+      space: "O(1)"
+    guarantees:
+      - "理論的に不可能な SLO を CI へ流さない"
+
+implementation_tasks:
+  - id: IMPL-PATE-001
+    priority: 1
+    requirement_ids:
+      - REQ-PATE-001
+    blockers:
+      - BAR-PATE-001
+    actions:
+      - "result_collector に phase_metrics 生成処理を実装する。"
+      - "meta.results.phase_metrics を全 profile_type で出力する。"
+    completion_criteria:
+      - "37シナリオ全てで phase_metrics が欠落しない"
+    verification_artifacts:
+      - "benchmark/meta/*.json"
+
+  - id: IMPL-PATE-002
+    priority: 2
+    requirement_ids:
+      - REQ-PATE-002
+    blockers:
+      - BAR-PATE-002
+    actions:
+      - "threshold スキーマを `min_*_rps` へ分解する。"
+      - "profile_type ごとに許可フィールドを制約する。"
+    completion_criteria:
+      - "曖昧な min_rps_achieved が新規シナリオで使用不可"
+    verification_artifacts:
+      - "scenario schema validation report"
+
+  - id: IMPL-PATE-003
+    priority: 3
+    requirement_ids:
+      - REQ-PATE-003
+    blockers:
+      - BAR-PATE-003
+    actions:
+      - "preflight lint を run_benchmark.sh の前段へ組み込む。"
+      - "無効閾値検出時は benchmark 実行を中止する。"
+    completion_criteria:
+      - "large_scale_seeded/pool_stress_large などの不整合設定を事前検出できる"
+    verification_artifacts:
+      - "preflight lint logs"
+      - "CI fail case records"
+
+non_functional_requirements:
+  performance:
+    - "閾値誤判定（達成不可能閾値の混入）を 0 件にする"
+    - "phase-aware 指標生成の追加オーバーヘッドを 1% 未満に抑える"
+  compatibility:
+    - "既存シナリオは移行期間中に自動変換または互換読み込みを提供する"
+  testing:
+    - "burst/step/ramp/steady それぞれの閾値判定ユニットテスト"
+    - "達成不可能閾値に対する preflight fail テスト"
+
+future_extensions:
+  - id: "EXT-PATE-001"
+    name: "SLO 自動提案"
+    description: |
+      過去実績からシナリオ別に妥当な閾値を自動提案する。
+    rationale: |
+      まずは誤判定防止を優先し、提案機能は安定化後に導入する。


### PR DESCRIPTION
## Summary

- phase-aware メトリクス（peak_phase_rps / sustain_phase_rps / weighted_rps / min_phase_rps）を標準出力に追加する
- 閾値スキーマの min_rps_achieved を廃止し min_peak_rps / min_sustain_rps / min_weighted_rps に分解して評価対象を明示する
- 実行前閾値 lint を導入し、理論的に達成不可能な閾値（large_scale_seeded / pool_stress_large 等）を事前に排除する

## Background

run 22083126035 で burst_spike_test (merged 500 RPS < 閾値 900) など 7 シナリオが誤 FAIL と判定された。
実測 phase 値は target をほぼ達成しており、merged RPS を min_rps と比較する設計が誤判定を誘発していた。

## Test plan

- [ ] burst / step / ramp / steady それぞれの閾値判定ユニットテストが通ること
- [ ] 達成不可能閾値に対する preflight fail テストが通ること
- [ ] 37 シナリオ全てで phase_metrics が欠落しないこと
- [ ] cargo fmt / cargo clippy --all-features --all-targets -- -D warnings / cargo doc --no-deps がパスすること

## Refs

- docs/internal/requirements/20260217_1110_phase_aware_threshold_evaluation_run22083126035.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)